### PR TITLE
Change values from generator into list

### DIFF
--- a/pytest_ansible/results.py
+++ b/pytest_ansible/results.py
@@ -93,5 +93,4 @@ class AdHocResult(object):
 
     def values(self):
         """Return a list of ModuleResult instances for each contacted inventory host."""
-        for k in self.contacted.keys():
-            yield getattr(self, k)
+        return [getattr(self, k) for k in self.contacted.keys()]

--- a/tests/test_adhoc_result.py
+++ b/tests/test_adhoc_result.py
@@ -32,7 +32,9 @@ def test_items(adhoc_result):
 
 def test_values(adhoc_result):
     values = adhoc_result.values()
-    assert isinstance(values, GeneratorType)
+    assert isinstance(values, list)
+    # assure that it is a copy
+    assert values is not adhoc_result.contacted.values()
     for count, val in enumerate(values, 1):
         assert isinstance(val, ModuleResult)
     assert count == len(ALL_HOSTS)


### PR DESCRIPTION
It is fairly annoying behavior that pytest-ansible returns a generator for this, because fairly common things someone expects to do with `.values()` from a dictionary like .pop and indexing can't be done without changing its type.