### PR TITLE
WIP - update fixtures to use session scope

### DIFF
--- a/pytest_ansible/fixtures.py
+++ b/pytest_ansible/fixtures.py
@@ -7,7 +7,7 @@ __all__ = ('ansible_module', 'ansible_facts', 'ansible_adhoc', 'localhost')
 log = get_logger(__name__)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def ansible_adhoc(request):
     """Return an inventory initialization method."""
     plugin = request.config.pluginmanager.getplugin("ansible")
@@ -17,14 +17,14 @@ def ansible_adhoc(request):
     return init_host_mgr
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def ansible_module(ansible_adhoc):
     """Return a subclass of BaseModuleDispatcher."""
     host_mgr = ansible_adhoc()
     return getattr(host_mgr, host_mgr.options['host_pattern'])
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def ansible_facts(ansible_module):
     """Return ansible_facts dictionary."""
     return ansible_module.setup()


### PR DESCRIPTION
Work in progress- this came up in the course of discussing a proposal (https://github.com/ansible/tower-qa/pull/2495). I doubt it will be as simple as just replacing "function" with "session", but this needs to happen if we are going to start using the ansible_facts fixture more often.

This PR updates the pytest-ansible fixtures to use the `session` scope rather than the `function` scope. 

Currently, these functions are run every time they are passed as an argument to a test. This represents a pretty major performance hit for any test utilizing the `ansible_facts` fixture, since it's going to perform a `setup` task (ssh connections and all). By moving it to session scope, we gather the facts once and then reuse the values. 

I could definitely use a sanity check from someone with more history