### PR TITLE
Pytest 4 1 compliant

### DIFF
--- a/pytest_ansible/plugin.py
+++ b/pytest_ansible/plugin.py
@@ -5,7 +5,6 @@ import ansible
 import ansible.constants
 import ansible.utils
 import ansible.errors
-import collections
 
 from pytest_ansible.logger import get_logger
 from pytest_ansible.fixtures import (ansible_adhoc, ansible_module, ansible_facts, localhost)
@@ -202,22 +201,9 @@ class PyTestAnsiblePlugin:
         kwargs = dict()
 
         # Override options from @pytest.mark.ansible
-        if request.scope == 'function':
-            if hasattr(request.function, 'ansible'):
-                kwargs = request.function.ansible.kwargs
-        elif request.scope == 'class':
-            if hasattr(request.cls, 'pytestmark') and isinstance(request.cls.pytestmark, collections.Iterable):
-                for pytestmark in request.cls.pytestmark:
-                    if pytestmark.name == 'ansible':
-                        kwargs = pytestmark.kwargs
-                    else:
-                        continue
-
-        # Was this fixture called in conjunction with a parametrized fixture
-        if 'ansible_host' in request.fixturenames:
-            kwargs['host_pattern'] = request.getfuncargvalue('ansible_host')
-        elif 'ansible_group' in request.fixturenames:
-            kwargs['host_pattern'] = request.getfuncargvalue('ansible_group')
+        marker = request.node.get_closest_marker('ansible')
+        if marker:
+            kwargs = marker.kwargs
 
         log.debug("request: %s" % kwargs)
         return kwargs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,20 +70,20 @@ def pytest_runtest_setup(item):
         has_ansible_v24 = parse_version(ansible.__version__) >= parse_version('2.4.0')
 
         # conditionally skip
-        if item.get_marker('requires_ansible_v1') and not has_ansible_v1:
+        if item.get_closest_marker('requires_ansible_v1') and not has_ansible_v1:
             pytest.skip("requires < ansible-2.*")
-        if item.get_marker('requires_ansible_v2') and has_ansible_v1:
+        if item.get_closest_marker('requires_ansible_v2') and has_ansible_v1:
             pytest.skip("requires >= ansible-2.*")
-        if item.get_marker('requires_ansible_v24') and not has_ansible_v24:
+        if item.get_closest_marker('requires_ansible_v24') and not has_ansible_v24:
             pytest.skip("requires >= ansible-2.4.*")
 
         # conditionally xfail
-        mark = item.get_marker('ansible_v1_xfail')
+        mark = item.get_closest_marker('ansible_v1_xfail')
         if mark and has_ansible_v1:
             item.add_marker(pytest.mark.xfail(reason="expected failure on < ansible-2.*",
                                               raises=mark.kwargs.get('raises')))
 
-        mark = item.get_marker('ansible_v2_xfail')
+        mark = item.get_closest_marker('ansible_v2_xfail')
         if mark and not has_ansible_v1:
             item.add_marker(pytest.xfail(reason="expected failure on >= ansible-2.*",
                                          raises=mark.kwargs.get('raises')))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,10 +34,10 @@ POSITIVE_HOST_PATTERNS = [
     ('!localhost', 2),
     ('all[0]', 1),
     ('all[-1]', 1),
-    pytest.mark.requires_ansible_v1(('*[0-1]', 1)),
-    pytest.mark.requires_ansible_v2(('*[0-1]', 2)),
-    pytest.mark.requires_ansible_v2(('*[0:1]', 2)),  # this is confusing, but how host slicing works on v2
-    pytest.mark.requires_ansible_v2(('*[0:]', 3)),
+    pytest.param('*[0-1]', 1, marks=pytest.mark.requires_ansible_v1()),
+    pytest.param('*[0-1]', 2, marks=pytest.mark.requires_ansible_v2()),
+    pytest.param('*[0:1]', 2, marks=pytest.mark.requires_ansible_v2()),  # this is confusing, but how host slicing works on v2
+    pytest.param('*[0:]', 3, marks=pytest.mark.requires_ansible_v2()),
 ]
 
 NEGATIVE_HOST_PATTERNS = [
@@ -47,10 +47,10 @@ NEGATIVE_HOST_PATTERNS = [
 
 POSITIVE_HOST_SLICES = [
     (slice(0, 0), 1),
-    pytest.mark.requires_ansible_v1((slice(0, 1), 1)),
-    pytest.mark.requires_ansible_v2((slice(0, 1), 2)),
-    pytest.mark.requires_ansible_v1((slice(0, 2), 2)),
-    pytest.mark.requires_ansible_v2((slice(0, 2), 3)),
+    pytest.param(slice(0, 1), 1, marks=pytest.mark.requires_ansible_v1()),
+    pytest.param(slice(0, 1), 2, marks=pytest.mark.requires_ansible_v2()),
+    pytest.param(slice(0, 2), 2, marks=pytest.mark.requires_ansible_v1()),
+    pytest.param(slice(0, 2), 3, marks=pytest.mark.requires_ansible_v2()),
     (slice(0), 1),
     (slice(1), 1),
     (slice(2), 1),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,7 +65,7 @@ NEGATIVE_HOST_SLICES = [
 
 def pytest_runtest_setup(item):
     # Conditionally skip tests that are pinned to a specific ansible version
-    if isinstance(item, item.Function):
+    if isinstance(item, pytest.Function):
         has_ansible_v1 = parse_version(ansible.__version__) < parse_version('2.0.0')
         has_ansible_v24 = parse_version(ansible.__version__) >= parse_version('2.4.0')
 

--- a/tests/test_module_result.py
+++ b/tests/test_module_result.py
@@ -111,8 +111,8 @@ def module_result_unreachable():
         ('module_result_failed', 'is_successful', False),
         ('module_result_changed', 'is_changed', True),
         ('module_result_changed', 'is_successful', True),
-        pytest.mark.skipif('True')(('module_result_skipped', 'is_skipped', True)),
-        pytest.mark.skipif('True')(('module_result_unreachable', 'is_unreachable', True)),
+        pytest.param('module_result_skipped', 'is_skipped', True, marks=pytest.mark.skipif('True')),
+        pytest.param('module_result_unreachable', 'is_unreachable', True, marks=pytest.mark.skipif('True')),
     ]
 )
 def test_is_property(request, fixture_name, prop, expected_result):

--- a/tests/test_module_result.py
+++ b/tests/test_module_result.py
@@ -116,5 +116,5 @@ def module_result_unreachable():
     ]
 )
 def test_is_property(request, fixture_name, prop, expected_result):
-    fixture = request.getfuncargvalue(fixture_name)
+    fixture = request.getfixturevalue(fixture_name)
     assert getattr(fixture, prop) == expected_result

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -190,10 +190,8 @@ def test_params_required_with_bogus_inventory_v2(testdir, option, recwarn):
     src = """
         import pytest
         def test_func(ansible_module):
-            with pytest.warns(UserWarning) as record:
+            with pytest.warns(UserWarning, match="provided hosts list is empty, only localhost is available"):
                 ansible_module.ping()
-            assert len(record) == 1
-            assert record[0].message.args[0] == "provided hosts list is empty, only localhost is available"
     """
     testdir.makepyfile(src)
 

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -135,7 +135,7 @@ def test_param_requires_value(testdir, required_value_parameter):
     """Verifies failure when not providing a value to a parameter that requires a value"""
 
     result = testdir.runpytest(*[required_value_parameter])
-    assert result.ret == EXIT_INTERRUPTED
+    assert result.ret == EXIT_USAGEERROR
     result.stderr.fnmatch_lines([
         '*: error: argument *%s*: expected one argument' % required_value_parameter,
     ])


### PR DESCRIPTION
This PR fix the tests in order to be compliant with pytest 4.1

I have split the PR in many commits in order make the review easier. I can squash the commits if you wish.

Please pay attention to commit b65d104dbc564be1fe8db75ba9e566ccbe093650 beacause i haven't find a doc that explain why this return code has changed. The new return code `EXIT_USAGEERROR` seems logic to me but ...

The tests on `ansible_devel` are failing because of a breaking change on ansible python API.  `CLI.base_parser()` does not exist anymore