### PR TITLE
Capture module failure in class ModuleResult

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ docs/_build/
 # PyBuilder
 target/
 
+# pycharm
+.idea/

--- a/pytest_ansible/__init__.py
+++ b/pytest_ansible/__init__.py
@@ -1,5 +1,5 @@
 """The pytest-ansible initialization."""
 
-__version__ = "2.2.2"
+__version__ = "2.2.3rc0"
 __author__ = "James Laska"
 __author_email__ = "<jlaska@ansible.com>"

--- a/pytest_ansible/module_dispatcher/v28.py
+++ b/pytest_ansible/module_dispatcher/v28.py
@@ -34,9 +34,12 @@ class ResultAccumulator(CallbackBase):
         self.unreachable = {}
 
     def v2_runner_on_failed(self, result, *args, **kwargs):
-        self.contacted[result._host.get_name()] = result._result
+        result2 = dict(failed=True)
+        result2.update(result._result)
+        self.contacted[result._host.get_name()] = result2
 
-    v2_runner_on_ok = v2_runner_on_failed
+    def v2_runner_on_ok(self, result):
+        self.contacted[result._host.get_name()] = result._result
 
     def v2_runner_on_unreachable(self, result):
         self.unreachable[result._host.get_name()] = result._result


### PR DESCRIPTION
Hello,

I am using pytest_ansible in one of my projects. In particular I am using pytest_ansible to test an action plugin I have developed. However, during the development of my negative test cases, I found the property `is_failed` in class `ModuleResult` is not catching the module failure due to the fact the class `ResultAccumulator` (the callback plugin capturing ansible result during test execution) did not include the key `failed` within `ModuleResult`. This PR includes just a few modifications based in version 2.2.2 which fix basically that allowing me now to assert on for instance `contacted.localhost.is_failed` upon a module error.

Cheers
Jose M. Prieto