### PR TITLE
Fix has_module for non-builtin modules

### DIFF
--- a/pytest_ansible/module_dispatcher/v1.py
+++ b/pytest_ansible/module_dispatcher/v1.py
@@ -22,6 +22,16 @@ class ModuleDispatcherV1(BaseModuleDispatcher):
     required_kwargs = ('inventory', 'inventory_manager', 'host_pattern')
 
     def has_module(self, name):
+        # Make sure we parse module_path and pass it to the loader,
+        # otherwise, only built-in modules will work.
+        if 'module_path' in self.options:
+            paths = self.options['module_path']
+            if isinstance(paths, (list, tuple, set)):
+                for path in paths:
+                    ansible.utils.module_finder.add_directory(path)
+            else:
+                ansible.utils.module_finder.add_directory(paths)
+
         return ansible.utils.module_finder.has_plugin(name)
 
     def _run(self, *module_args, **complex_args):

--- a/pytest_ansible/module_dispatcher/v2.py
+++ b/pytest_ansible/module_dispatcher/v2.py
@@ -49,6 +49,16 @@ class ModuleDispatcherV2(BaseModuleDispatcher):
     required_kwargs = ('inventory', 'inventory_manager', 'variable_manager', 'host_pattern', 'loader')
 
     def has_module(self, name):
+        # Make sure we parse module_path and pass it to the loader,
+        # otherwise, only built-in modules will work.
+        if 'module_path' in self.options:
+            paths = self.options['module_path']
+            if isinstance(paths, (list, tuple, set)):
+                for path in paths:
+                    ansible.plugins.module_loader.add_directory(path)
+            else:
+                ansible.plugins.module_loader.add_directory(paths)
+
         return ansible.plugins.module_loader.has_plugin(name)
         # return module_loader.has_plugin(name)
 

--- a/pytest_ansible/module_dispatcher/v24.py
+++ b/pytest_ansible/module_dispatcher/v24.py
@@ -51,6 +51,15 @@ class ModuleDispatcherV24(ModuleDispatcherV2):
     required_kwargs = ('inventory', 'inventory_manager', 'variable_manager', 'host_pattern', 'loader')
 
     def has_module(self, name):
+        # Make sure we parse module_path and pass it to the loader,
+        # otherwise, only built-in modules will work.
+        if 'module_path' in self.options:
+            paths = self.options['module_path']
+            if isinstance(paths, (list, tuple, set)):
+                for path in paths:
+                    module_loader.add_directory(path)
+            else:
+                module_loader.add_directory(paths)
 
         return module_loader.has_plugin(name)
 

--- a/pytest_ansible/module_dispatcher/v28.py
+++ b/pytest_ansible/module_dispatcher/v28.py
@@ -53,6 +53,15 @@ class ModuleDispatcherV28(ModuleDispatcherV2):
     required_kwargs = ('inventory', 'inventory_manager', 'variable_manager', 'host_pattern', 'loader')
 
     def has_module(self, name):
+        # Make sure we parse module_path and pass it to the loader,
+        # otherwise, only built-in modules will work.
+        if 'module_path' in self.options:
+            paths = self.options['module_path']
+            if isinstance(paths, (list, tuple, set)):
+                for path in paths:
+                    module_loader.add_directory(path)
+            else:
+                module_loader.add_directory(paths)
 
         return module_loader.has_plugin(name)
 


### PR DESCRIPTION
When `py.test` is invoked with the `--ansible-module-path` flag, this flag
is correctly passed down to the underlying module, but the Ansible
module loader is never informed that this module path should be
searched. Tell Anisble about it so it gives us correct results and
doesn't prevent us from executing modules that otherwise would succeed.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

---

This has been experienced in the wild in [PKI's CI pipeline](https://github.com/dogtagpki/pki/pull/3351/checks?check_run_id=1298621481).