### PR TITLE
Obtain verbosity from parent pytest command (making output less verbose)

### DIFF
--- a/pytest_ansible/module_dispatcher/v28.py
+++ b/pytest_ansible/module_dispatcher/v28.py
@@ -1,3 +1,5 @@
+import sys
+
 import warnings
 import ansible.constants
 import ansible.utils
@@ -84,7 +86,15 @@ class ModuleDispatcherV28(ModuleDispatcherV2):
             raise ansible.errors.AnsibleError("Specified hosts and/or --limit does not match any hosts")
 
         # Pass along cli options
-        args = ['pytest-ansible', '-vvvvv', self.options['host_pattern']]
+        args = ['pytest-ansible']
+        verbosity = None
+        for verbosity_syntax in ('-v', '-vv', '-vvv', '-vvvv', '-vvvvv'):
+            if verbosity_syntax in sys.argv:
+                verbosity = verbosity_syntax
+                break
+        if verbosity is not None:
+            args.append(verbosity_syntax)
+        args.extend([self.options['host_pattern']])
         for argument in ('connection', 'user', 'become', 'become_method', 'become_user', 'module_path'):
             arg_value = self.options.get(argument)
             argument = argument.replace('_', '-')


### PR DESCRIPTION
Connect https://github.com/ansible/pytest-ansible/issues/44

As people have made increasingly frequent use of pytest-ansible over the years, I have noticed a lot of output which is extremely verbose and has no chance of being useful. This is particularly true of the connection debugging commands, like those that start with `SSH: EXEC ssh -vvv -o `

Looking into it, it appeared that the `ssh` verbosity is passed along by Ansible itself, according to its own verbosity. This seems to be a problem because pytest-ansible will always default Ansible's verbosity to 5.

It seems like the most sensible action here is to derive the Ansible (and thus connection) verbosity from the `py.test` CLI verbosity so that people retain the choice of very verbose, or very quiet output.