### PR TITLE
Revert "Add support to ansible inventory env var"

### DIFF
--- a/pytest_ansible/plugin.py
+++ b/pytest_ansible/plugin.py
@@ -1,6 +1,5 @@
 """PyTest Ansible Plugin."""
 
-import os
 import pytest
 import ansible
 import ansible.constants
@@ -32,11 +31,10 @@ def pytest_addoption(parser):
     """Add options to control ansible."""
 
     group = parser.getgroup('pytest-ansible')
-    env_inventory = os.getenv("ANSIBLE_INVENTORY", ansible.constants.DEFAULT_HOST_LIST)
     group.addoption('--inventory', '--ansible-inventory',
                     action='store',
                     dest='ansible_inventory',
-                    default=env_inventory,
+                    default=ansible.constants.DEFAULT_HOST_LIST,
                     metavar='ANSIBLE_INVENTORY',
                     help='ansible inventory file URI (default: %(default)s)')
     group.addoption('--host-pattern', '--ansible-host-pattern',


### PR DESCRIPTION
Reverts ansible/pytest-ansible#60
- ansible/pytest-ansible#60

I think that this was a mistake.
I could have used the `export PYTEST_ADDOPTS="--inventory=/path/to/file"` instead.