### PR TITLE
Stop using standalone mock library

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,6 @@ repos:
         additional_dependencies:
           - pytest
           - ansible-core
-          - types-mock
           - types-pkg_resources
   - repo: https://github.com/jazzband/pip-tools
     rev: 6.12.3

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -4,10 +4,7 @@ import ansible
 from pkg_resources import parse_version
 from pytest_ansible.has_version import has_ansible_v28
 
-try:
-    import mock
-except ImportError:
-    from unittest import mock  # type: ignore
+from unittest import mock
 import re
 
 try:


### PR DESCRIPTION
Since python 3.3 this is no longer needed