### PR TITLE
Add missing dependency to ansible-core

### DIFF
--- a/.config/requirements-test.txt
+++ b/.config/requirements-test.txt
@@ -1,3 +1,2 @@
-ansible-core
 coverage
 molecule

--- a/.config/requirements.in
+++ b/.config/requirements.in
@@ -1,2 +1,3 @@
+ansible-core >= 2.12.10
 pytest>=6,<8.0.0
 setuptools


### PR DESCRIPTION
This avoids having a `ModuleNotFoundError: No module named 'ansible'` when ansible-core module is not installed.

The version used is the same as `ansible-lint` and `molecule`.