### PR TITLE
Require minimum python version to 3.9

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -28,7 +28,7 @@ jobs:
         id: generate_matrix
         uses: coactions/dynamic-matrix@v1
         with:
-          min_python: "3.7"
+          min_python: "3.9"
           max_python: "3.12"
           other_names: |
             lint

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To use `pytest-ansible-units`, follow these steps:
 pip install pytest-ansible
 ```
 
-2. Ensure you have Python 3.8 or greater, ansible-core, and pyyaml installed.
+2. Ensure you have Python 3.9 or greater, ansible-core, and pyyaml installed.
 
 3. Depending on your preferred directory structure, you can clone collections
    into the appropriate paths.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 # https://peps.python.org/pep-0621/#readme
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 dynamic = ["version", "dependencies", "optional-dependencies"]
 name = "pytest-ansible"
 description = "Plugin for pytest to simplify calling ansible modules from tests or fixtures"
@@ -26,8 +26,6 @@ classifiers = [
   'Topic :: Utilities',
   'Programming Language :: Python',
   'Programming Language :: Python :: 3',
-  'Programming Language :: Python :: 3.7',
-  'Programming Language :: Python :: 3.8',
   'Programming Language :: Python :: 3.9',
   'Programming Language :: Python :: 3.10',
   'Programming Language :: Python :: 3.11',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ ignore = [
   "T",
   "TRY",
 ]
-target-version = "py37"
+target-version = "py39"
 # Same as Black.
 line-length = 88
 

--- a/src/pytest_ansible/module_dispatcher/__init__.py
+++ b/src/pytest_ansible/module_dispatcher/__init__.py
@@ -1,6 +1,6 @@
 """Define BaseModuleDispatcher class."""
 
-from typing import Sequence
+from collections.abc import Sequence
 
 from pytest_ansible.errors import AnsibleModuleError
 

--- a/tox.ini
+++ b/tox.ini
@@ -32,8 +32,6 @@ setenv =
   ANSIBLE_LOCAL_TEMP = {envdir}/.ansible-local
   PIP_CONSTRAINT = {toxinidir}/.config/requirements.txt
   devel: PIP_CONSTRAINT = /dev/null
-  py37: PIP_CONSTRAINT = /dev/null
-  py38: PIP_CONSTRAINT = /dev/null
 extras =
   test
 allowlist_externals =


### PR DESCRIPTION
Unify the minimum python version used by others devtools projects.