### PR TITLE
Change names of detected molecule tests to avoid name duplication

### DIFF
--- a/.config/requirements-test.txt
+++ b/.config/requirements-test.txt
@@ -1,3 +1,4 @@
 ansible-core
 coverage
 molecule
+pytest-plus>=0.6.0

--- a/.config/requirements.txt
+++ b/.config/requirements.txt
@@ -66,6 +66,7 @@ pycparser==2.21
 pygments==2.16.1
 pymdown-extensions==10.3
 pytest==7.4.2
+pytest-plus==0.6.0
 python-dateutil==2.8.2
 python-slugify==8.0.1
 pyyaml==6.0.1

--- a/src/pytest_ansible/molecule.py
+++ b/src/pytest_ansible/molecule.py
@@ -20,6 +20,7 @@ from molecule.config import ansible_version
 
 
 logger = logging.getLogger(__name__)
+counter = 0
 
 
 def molecule_pytest_configure(config):
@@ -100,10 +101,13 @@ class MoleculeFile(pytest.File):
 
     def collect(self):
         """Test generator."""
+        # pylint: disable=global-statement
+        global counter
         if hasattr(MoleculeItem, "from_parent"):
-            yield MoleculeItem.from_parent(name="test", parent=self)
+            yield MoleculeItem.from_parent(name=f"test{counter}", parent=self)
         else:
-            yield MoleculeItem("test", self)
+            yield MoleculeItem(f"test{counter}", self)
+        counter += 1
 
     def __str__(self) -> str:
         """Return test name string representation."""

--- a/tests/integration/test_molecule.py
+++ b/tests/integration/test_molecule.py
@@ -29,7 +29,7 @@ def test_molecule_collect() -> None:
         pytest.fail(exc.stderr)
 
     assert proc.returncode == 0
-    assert "test[default]" in proc.stdout
+    assert "test1[default]" in proc.stdout
 
 
 def test_molecule_disabled() -> None:


### PR DESCRIPTION
- avoid duplicate test names
- improve test id names
- enable pytest-plus to detect regressions
