### PR TITLE
Avoid early molecule importing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,8 @@ required-version = "0.1.1"
 select = ["ALL"]
 ignore = [
   "E501", # we use black
+  "D203", # incompatible with D211
+  "D213", # incompatible with D212
   # temporary disabled until we fix them:
   "ANN",
   "ARG",

--- a/src/pytest_ansible/molecule.py
+++ b/src/pytest_ansible/molecule.py
@@ -2,6 +2,7 @@
 # pylint: disable=protected-access
 from __future__ import annotations
 
+import importlib.util
 import logging
 import os
 import shlex
@@ -15,8 +16,15 @@ import pkg_resources
 import pytest
 import yaml
 
-from molecule.api import drivers
-from molecule.config import ansible_version
+from ansible_compat.config import ansible_version
+
+
+# Do not add molecule imports here as it does have side effects due to console
+# redirection. We need to do these as lazy as possible.
+
+
+molecule_spec = importlib.util.find_spec("molecule")
+HAS_MOLECULE = molecule_spec is not None
 
 
 logger = logging.getLogger(__name__)
@@ -62,6 +70,8 @@ def molecule_pytest_configure(config):
         warnings.filterwarnings("ignore", category=DeprecationWarning)
 
         config.option.molecule = {}
+        from molecule.api import drivers
+
         for driver in map(str, drivers()):
             config.addinivalue_line(
                 "markers",

--- a/src/pytest_ansible/plugin.py
+++ b/src/pytest_ansible/plugin.py
@@ -22,15 +22,7 @@ from pytest_ansible.fixtures import (
 )
 from pytest_ansible.host_manager import get_host_manager
 
-
-try:
-    from .molecule import MoleculeFile, MoleculeScenario
-
-    HAS_MOLECULE = True
-except ImportError:
-    HAS_MOLECULE = False
-
-
+from .molecule import HAS_MOLECULE, MoleculeFile, MoleculeScenario
 from .units import inject, inject_only
 
 
@@ -228,7 +220,10 @@ def pytest_collect_file(
     if not parent.config.option.molecule:
         return None
     if not HAS_MOLECULE:
-        pytest.exit("molecule not installed or found.")
+        pytest.exit(
+            f"molecule not installed or found, unable to collect test {file_path}",
+        )
+        return None
     if file_path and file_path.is_symlink():
         return None
     if file_path and file_path.name == "molecule.yml":

--- a/tests/integration/test_molecule.py
+++ b/tests/integration/test_molecule.py
@@ -43,7 +43,7 @@ def test_molecule_disabled() -> None:
         text=True,
     )
     assert proc.returncode == 4
-    assert "ERROR: found no collectors" in proc.stdout
+    assert "ERROR: found no collectors" in proc.stderr
 
 
 def test_molecule_runtest() -> None:


### PR DESCRIPTION
This fixed a bug where console redirection made by molecule affected
pytest execution by adding one new extra newline at each test.

Also this removes use of a deprecated function from molecule.
