### PR TITLE
Rename deprecated startdir fixture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ var/
 *.eggs
 
 # PyInstaller
-#  Usually these files are written by a python script from a template 
+#  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
@@ -57,3 +57,6 @@ target/
 
 # pycharm
 .idea/
+
+# readthedocs check
+/_readthedocs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+---
+repos:
+  - repo: meta
+    hooks:
+      - id: check-useless-excludes

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,24 @@
+---
+version: 2
+
+mkdocs:
+  fail_on_warning: false
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+  commands:
+    - pip install --user tox
+    - python3 -m tox -e docs -- --strict --site-dir=_readthedocs/html/
+python:
+  install:
+    - method: pip
+      path: tox
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+submodules:
+  include: all
+  recursive: true

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,11 @@
+# Ansible Pytest Documentation
+
+## About Ansible Pytest
+
+Ansible Pytest is a plugin for ``py.test`` which adds several fixtures
+for running ``ansible`` modules, or inspecting ``ansible_facts``.  While one
+can simply call out to ``ansible`` using the ``subprocess`` module, having to
+parse stdout to determine the outcome of the operation is unpleasant and prone
+to error.  With ``pytest-ansible``, modules return JSON data which you can
+inspect and act on, much like with an ansible
+[playbook](http://docs.ansible.com/playbooks.html).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,42 @@
+---
+site_name: Ansible Pytest Documentation
+site_url: https://ansible.readthedocs.io/projects/pytest-ansible/
+repo_url: https://github.com/ansible/pytest-ansible
+edit_uri: blob/main/docs/
+copyright: Copyright © 2023 Red Hat, Inc.
+docs_dir: docs
+strict: true
+
+
+extra:
+  social:
+    - icon: fontawesome/brands/python
+      link: https://pypi.org/project/pytest-ansible/
+      name: PyPI
+    - icon: fontawesome/solid/scroll
+      link: https://github.com/ansible/pytest-ansible/releases
+      name: Releases
+    - icon: simple/mastodon
+      link: https://fosstodon.org/@ansible
+      name: Mastodon
+    - icon: simple/matrix
+      link: https://matrix.to/#/#devtools:ansible.com
+      name: Matrix
+    - icon: fontawesome/solid/comments
+      link: https://github.com/ansible/pytest-ansible/discussions
+      name: Discussions
+    - icon: fontawesome/brands/github-alt
+      link: https://github.com/ansible/pytest-ansible
+      name: GitHub
+
+nav:
+  - User Guide:
+      - home: index.md
+
+markdown_extensions:
+  - admonition
+  - def_list
+  - footnotes
+  - toc:
+      toc_depth: 2
+      permalink: true

--- a/pytest_ansible/plugin.py
+++ b/pytest_ansible/plugin.py
@@ -165,7 +165,7 @@ class PyTestAnsiblePlugin:
         """Initialize plugin."""
         self.config = config
 
-    def pytest_report_header(self, config, startdir):
+    def pytest_report_header(self, config, start_path):
         """Return the version of ansible."""
         return 'ansible: %s' % ansible.__version__
 

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ setup(
     zip_safe=False,
     tests_require=['tox'],
     # setup_requires=['pypandoc<1.2.0', 'setuptools-markdown'],
-    setup_requires=['setuptools-markdown'],
+    setup_requires=['pypandoc<1.8', 'setuptools-markdown'],
     install_requires=['ansible<8.0.0', 'pytest'],
     cmdclass={
         'test': ToxTestCommand,

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,5 @@
 tox
-pytest<6.0.0
+pytest
 coverage
 coveralls
 mock
-pylama
-pylama_pylint

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ ANSIBLE_VERSION =
     v212: ansible_v212
     v213: ansible_v213
 
-[testenv]
+[testenv:test]
 # The following does not work properly ... demons
 # commands = py.test -v --tb=native --doctest-glob='*.md' --cov=pytest_ansible {posargs}
 # commands = python setup.py test --pytest-args "{posargs}"
@@ -23,7 +23,11 @@ commands =
     coverage run --parallel --source pytest_ansible -m pytest -v --doctest-glob='*.md' {posargs}
     coverage combine
     coverage report -m
-passenv = ANSIBLE_DEBUG TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+passenv =
+    ANSIBLE_DEBUG
+    TRAVIS
+    TRAVIS_JOB_ID
+    TRAVIS_BRANCH
 setenv =
     ANSIBLE_REMOTE_TEMP = {envdir}/.ansible-remote
     ANSIBLE_LOCAL_TEMP = {envdir}/.ansible-local
@@ -67,22 +71,18 @@ markers =
     requires_ansible_v2
     requires_ansible_v24
 
-[pylama]
-format = pylint
-skip = */.tox/*,*/.env/*
-linters = mccabe,pep8,pyflakes,pydocstyle,pycodestyle
-ignore = F0401,C0111,E731,D100,W0621,W0108,R0201,W0401,W0614,W0212,C901,R0914,I0011,D211,D102,D213
-
-[pylama:pep8]
-max_line_length = 120
-
-[pylama:pylint]
-max_line_length = 120
-additional_builtins = config,self,item,skip
-
-[pylama:mccabe]
-max_complexity = 11
-
-[pylama:pycodestyle]
-max_line_length = 120
-max-line-length = 120
+[testenv:docs]
+description = Builds docs
+deps =
+  mkdocs
+extras =
+  docs
+setenv =
+  # Disable colors until markdown-exec supports it:
+  # https://github.com/pawamoy/markdown-exec/issues/11
+  NO_COLOR = 1
+  TERM = dump
+skip_install = false
+usedevelop = true
+commands =
+  mkdocs build {posargs:}


### PR DESCRIPTION
Rename deprecated startdir to start_path. See  https://docs.pytest.org/en/8.0.x/deprecations.html#py-path-local-arguments-for-hooks-replaced-with-pathlib-path

Similar issue can be found here: https://github.com/pytest-dev/pytest/issues/12061