### PR TITLE
chore: Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ sort = "Cover"
 [tool.coverage.run]
 branch = false # https://github.com/nedbat/coveragepy/issues/605
 concurrency = ["multiprocessing", "thread"]
+omit = ["_version.py"]
 parallel = true
 source_pkgs = ["pytest_ansible"]
 


### PR DESCRIPTION
Don't report coverage on _version.py. This is only an issue when running locally but can be misleading when comparing to CI results.
