### PR TITLE
Community comms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - name: Retreive the forum post script from team-devtools
+      - name: Retrieve the forum post script from team-devtools
         run: curl -O https://raw.githubusercontent.com/ansible/team-devtools/main/.github/workflows/forum_post.py
 
       - name: Run the forum post script

--- a/README.md
+++ b/README.md
@@ -600,7 +600,8 @@ def test_inventory_unreachable(ansible_module):
 
 ## Communication
 
-Refer to the [Communication](https://ansible.readthedocs.io/projects/pytest-ansible/community/#community)
+Refer to the
+[Communication](https://ansible.readthedocs.io/projects/pytest-ansible/community/#community)
 section of the documentation to find out how to get in touch with us.
 
 You can also find more information in the
@@ -614,7 +615,8 @@ the same before you submit a pull request.
 
 ## Code of Conduct
 
-Please see the official [Ansible Community Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html).
+Please see the official
+[Ansible Community Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -615,7 +615,7 @@ the same before you submit a pull request.
 
 ## Code of Conduct
 
-Please see the official
+Please see the
 [Ansible Community Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html).
 
 ## License

--- a/README.md
+++ b/README.md
@@ -598,11 +598,23 @@ def test_inventory_unreachable(ansible_module):
         assert result['failed'] == True
 ```
 
+## Communication
+
+Refer to the [Communication](https://ansible.readthedocs.io/projects/pytest-ansible/community/#community)
+section of the documentation to find out how to get in touch with us.
+
+You can also find more information in the
+[Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html).
+
 ## Contributing
 
 Contributions are very welcome. Tests can be run with
 [tox](https://tox.wiki/en/latest/), please ensure the coverage at least stays
 the same before you submit a pull request.
+
+## Code of Conduct
+
+Please see the official [Ansible Community Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html).
 
 ## License
 

--- a/docs/community.md
+++ b/docs/community.md
@@ -2,18 +2,20 @@
 
 Connect with the pytest-ansible community!
 
-Join the Ansible forum to ask questions, get help, and interact with the community.
+Join the Ansible forum to ask questions, get help, and interact with the
+community.
 
-* [Get Help](https://forum.ansible.com/c/help/6): get help or help others.
-  Please add appropriate tags if you start new discussions, for example you
-  can use the `devtools` tag.
-  For example, you can filter topics tagged as [`eda-server`](https://forum.ansible.com/tag/eda-server)
-* [Social Spaces](https://forum.ansible.com/c/chat/4): meet and interact with
+- [Get Help](https://forum.ansible.com/c/help/6): get help or help others.
+  Please add appropriate tags if you start new discussions, for example you can
+  use the `devtools` tag. For example, you can filter topics tagged as
+  [`eda-server`](https://forum.ansible.com/tag/eda-server)
+- [Social Spaces](https://forum.ansible.com/c/chat/4): meet and interact with
   fellow enthusiasts.
-* [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide
+- [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide
   announcements including social events.
 
 To get release announcements and important changes from the community, see the
 [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn).
 
-If you encounter security-related concerns, report them via email to [security@ansible.com](mailto:security@ansible.com).
+If you encounter security-related concerns, report them via email to
+[security@ansible.com](mailto:security@ansible.com).

--- a/docs/community.md
+++ b/docs/community.md
@@ -1,0 +1,19 @@
+# Community
+
+Connect with the pytest-ansible community!
+
+Join the Ansible forum to ask questions, get help, and interact with the community.
+
+* [Get Help](https://forum.ansible.com/c/help/6): get help or help others.
+  Please add appropriate tags if you start new discussions, for example you
+  can use the `devtools` tag.
+  For example, you can filter topics tagged as [`eda-server`](https://forum.ansible.com/tag/eda-server)
+* [Social Spaces](https://forum.ansible.com/c/chat/4): meet and interact with
+  fellow enthusiasts.
+* [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide
+  announcements including social events.
+
+To get release announcements and important changes from the community, see the
+[Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn).
+
+If you encounter security-related concerns, report them via email to [security@ansible.com](mailto:security@ansible.com).

--- a/docs/community.md
+++ b/docs/community.md
@@ -7,8 +7,7 @@ community.
 
 - [Get Help](https://forum.ansible.com/c/help/6): get help or help others.
   Please add appropriate tags if you start new discussions, for example you can
-  use the `devtools` tag. For example, you can filter topics tagged as
-  [`eda-server`](https://forum.ansible.com/tag/eda-server)
+  use the `devtools` tag.
 - [Social Spaces](https://forum.ansible.com/c/chat/4): meet and interact with
   fellow enthusiasts.
 - [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,9 +33,9 @@ extra:
     - icon: simple/matrix
       link: https://matrix.to/#/#devtools:ansible.com
       name: Matrix
-    - icon: fontawesome/solid/comments
-      link: https://github.com/ansible/pytest-ansible/discussions
-      name: Discussions
+    - icon: fontawesome/brands/discourse
+      link: https://forum.ansible.com/c/project/7
+      name: Ansible forum
     - icon: fontawesome/brands/github-alt
       link: https://github.com/ansible/pytest-ansible
       name: GitHub

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
       - home: index.md
       - installing.md
       - getting_started.md
+      - community.md
 
 plugins:
   - autorefs


### PR DESCRIPTION
As a part of the [Consolidating Ansible discussion platforms initiative](https://forum.ansible.com/t/proposal-consolidating-ansible-discussion-platforms/6812), this PR adds the communication section template defined by the community to the README and the docsite. Similar PRs are now being raised across all the Ansible ecosystem projects.

Thanks!