### PR TITLE
enable `stdout` / `stderr` from `MoleculeScenario.test()`

### DIFF
--- a/src/pytest_ansible/molecule.py
+++ b/src/pytest_ansible/molecule.py
@@ -290,7 +290,7 @@ class MoleculeScenario:
         """
         return subprocess.run(
             args=[sys.executable, "-m", "molecule", "test", "-s", self.name],
-            capture_output=False,
+            capture_output=True,
             check=False,
             cwd=self.parent_directory,
             shell=False,


### PR DESCRIPTION
This pull request enables `stdout` and `stderr` from the output `MoleculeScenario`'s `test()`. It _seems_ like the intent was to enable this from result (i.e., `subprocess.CompletedProcess`) because `text=True` was configured to the run.