### PR TITLE
Fix bug with additional collections paths not being strings

### DIFF
--- a/.config/pydoclint-baseline.txt
+++ b/.config/pydoclint-baseline.txt
@@ -354,9 +354,6 @@ tests/test_plugin.py
 tests/unit/test_unit.py
     DOC101: Function `test_inject`: Docstring contains fewer arguments than in function signature.
     DOC103: Function `test_inject`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch, tmp_path: Path].
-    DOC101: Function `mock_get_collection_name`: Docstring contains fewer arguments than in function signature.
-    DOC103: Function `mock_get_collection_name`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [start_path: str].
-    DOC201: Function `mock_get_collection_name` does not have a return section in docstring
     DOC101: Function `test_inject_only`: Docstring contains fewer arguments than in function signature.
     DOC103: Function `test_inject_only`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch, tmp_path: Path].
 --------------------

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -21,8 +21,9 @@ jobs:
     uses: ansible/team-devtools/.github/workflows/tox.yml@main
     with:
       max_python: "3.13"
-      jobs_producing_coverage: 7
+      jobs_producing_coverage: 8
       other_names: |
+        devel
         docs
         lint
         pkg

--- a/src/pytest_ansible/units.py
+++ b/src/pytest_ansible/units.py
@@ -104,17 +104,19 @@ def inject(start_path: Path) -> None:
                 os.symlink(entry, name_dir / entry.name)
 
     # Configuration option for additional collection paths
-    additional_collections_paths = [Path("~/.ansible/collections").expanduser()]
+    additional_collections_paths: list[str] = [
+        Path("~/.ansible/collections").expanduser().as_posix()
+    ]
 
     # Check if the environment variable is set for additional paths
     if "COLLECTIONS_PATH" in os.environ and "COLLECTIONS_PATHS" in os.environ:
         additional_collections_paths.extend(
-            os.environ.get("COLLECTIONS_PATH", "").split(os.pathsep)  # type: ignore[arg-type]
+            os.environ.get("COLLECTIONS_PATH", "").split(os.pathsep)
             + os.environ.get("COLLECTIONS_PATHS", "").split(os.pathsep),
         )
     logger.info("Additional Collections Paths: %s", additional_collections_paths)
 
-    acf_inject(paths=[str(collections_dir), *additional_collections_paths])  # type: ignore[list-item]
+    acf_inject(paths=[str(collections_dir), *additional_collections_paths])
 
     # Inject the path for the collection into sys.path
     sys.path.insert(0, str(collections_dir))
@@ -123,8 +125,8 @@ def inject(start_path: Path) -> None:
     # Set the environment variable as a courtesy for integration tests
     envvar_name = determine_envvar()
     # Assuming additional_collections_paths is a list of PosixPath objects
-    additional_collections_paths = [str(path) for path in additional_collections_paths]  # type: ignore[misc]
-    env_paths = os.pathsep.join([str(collections_dir), *additional_collections_paths])  # type: ignore[list-item]
+    additional_collections_paths = [str(path) for path in additional_collections_paths]
+    env_paths = os.pathsep.join([str(collections_dir), *additional_collections_paths])
     logger.info("Setting %s to %s", envvar_name, env_paths)
     os.environ[envvar_name] = env_paths
 

--- a/tests/test_adhoc.py
+++ b/tests/test_adhoc.py
@@ -163,12 +163,18 @@ def test_become(pytester, option):  # type: ignore[no-untyped-def]  # noqa: ANN0
             assert len(contacted) == len(ansible_module)
             for result in contacted.values():
                 # Assert test failed as expected
-                if parse_version(ansible.__version__) < parse_version('2.4.0'):
+                if parse_version(ansible.__version__) >= parse_version('2.19.0.dev0'):
+                    assert result["failed"], "Test did not fail as expected"
+                    assert (
+                        "Failed to set permissions on the temporary files Ansible needs to create when becoming an unprivileged user"
+                        in result["msg"]
+                    )
+                elif parse_version(ansible.__version__) < parse_version('2.4.0'):
                     assert 'failed' in result, "Missing expected field in JSON response: failed"
                     assert result['failed'], "Test did not fail as expected"
 
                 # Assert expected failure message
-                if parse_version(ansible.__version__) >= parse_version('2.0.0'):
+                elif parse_version(ansible.__version__) >= parse_version('2.0.0'):
                     assert 'msg' in result, "Missing expected field in JSON response: msg"
                     assert result['msg'].startswith('Failed to set permissions on the temporary files Ansible needs ' \
                         'to create when becoming an unprivileged user')

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -31,11 +31,14 @@ def test_inject(
     """
     caplog.set_level(logging.DEBUG)
 
-    def mock_get_collection_name(start_path: str) -> tuple[str, str]:  # noqa: ARG001
+    def mock_get_collection_name(start_path: Path) -> tuple[str | None, str | None]:  # noqa: ARG001
         """Mock the get_collection_name function.
 
-        :param start_path: The path to the root of the collection
-        :returns: A tuple of the namespace and name
+        Args:
+            start_path: The Path to the root of the collection
+
+        Returns:
+            A tuple of the namespace and name
         """
         return "namespace", "name"
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,13 @@ requires =
     tox-extra>=2.0.2
     tox-uv>=1.20.2
 env_list =
+    py
     deps
     devel
     docs
     lint
     milestone
     pkg
-    py
 skip_missing_interpreters = true
 
 [testenv]
@@ -18,10 +18,10 @@ description =
     Run pytest
     devel: with ansible devel branch
 package = editable
-extras =
-    test
 deps =
     devel: ansible-core @ git+https://github.com/ansible/ansible.git  # GPLv3+
+extras =
+    test
 pass_env =
     CI
     CONTAINER_*

--- a/tox.ini
+++ b/tox.ini
@@ -4,19 +4,24 @@ requires =
     tox-extra>=2.0.2
     tox-uv>=1.20.2
 env_list =
-    py
     deps
+    devel
     docs
     lint
     milestone
     pkg
+    py
 skip_missing_interpreters = true
 
 [testenv]
-description = Run pytest under {basepython}
+description =
+    Run pytest
+    devel: with ansible devel branch
 package = editable
 extras =
     test
+deps =
+    devel: ansible-core @ git+https://github.com/ansible/ansible.git  # GPLv3+
 pass_env =
     CI
     CONTAINER_*
@@ -79,7 +84,7 @@ commands =
     mkdocs build {posargs:--strict --site-dir=_readthedocs/html/}
 
 [testenv:lint]
-description = Enforce quality standards under {basepython}
+description = Enforce quality standards
 skip_install = true
 deps =
     pre-commit


### PR DESCRIPTION
Fixes bug found while testing the data tagging feature related to incorrectly sending a Path to ansible where str was expected. It seems to be related to devel branch, so this change is also enabling testing of devel branch too.

The bug was in our code and can be used as a classic example of abuse of type ignores which underlined the bug in the first place.

Related: https://github.com/ansible/ansible/pull/84621
Related: https://issues.redhat.com/browse/AAP-41586