### PR TITLE
Deprecate features no longer supported with ansible-core 2.19

### DIFF
--- a/src/pytest_ansible/has_version.py
+++ b/src/pytest_ansible/has_version.py
@@ -9,9 +9,8 @@ from packaging.version import parse as parse_version
 
 has_ansible_v2 = parse_version(ansible.__version__) >= parse_version("2.0.0")
 has_ansible_v24 = parse_version(ansible.__version__) >= parse_version("2.4.0")
-has_ansible_v28 = parse_version(ansible.__version__) >= parse_version(
-    "2.8.0.dev0",
-) or parse_version(ansible.__version__) >= parse_version("2.8.0")
+has_ansible_v28 = parse_version(ansible.__version__) >= parse_version("2.8.0.dev0")
 has_ansible_v29 = parse_version(ansible.__version__) >= parse_version("2.9.0")
 has_ansible_v212 = parse_version(ansible.__version__) >= parse_version("2.12.0")
 has_ansible_v213 = parse_version(ansible.__version__) >= parse_version("2.13.0")
+has_ansible_v219 = parse_version(ansible.__version__) >= parse_version("2.19.0.dev0")

--- a/src/pytest_ansible/host_manager/base.py
+++ b/src/pytest_ansible/host_manager/base.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import ansible
 
+from typing_extensions import deprecated
 
+
+@deprecated("Host management is deprecated and will be removed in a future release")
 class BaseHostManager:
     """The BaseHostManager class provides a base class for managing ansible inventory hosts.
 

--- a/src/pytest_ansible/plugin.py
+++ b/src/pytest_ansible/plugin.py
@@ -21,6 +21,7 @@ from pytest_ansible.fixtures import (
     fixture_ansible_module,
     localhost,
 )
+from pytest_ansible.has_version import has_ansible_v219
 from pytest_ansible.host_manager.utils import get_host_manager
 
 from .molecule import HAS_MOLECULE, MoleculeFile, MoleculeScenario
@@ -240,6 +241,9 @@ def pytest_generate_tests(metafunc):  # type: ignore[no-untyped-def]  # noqa: AN
         pytest.UsageError: If the required --ansible-* parameters were not provided.
     """
     if "ansible_host" in metafunc.fixturenames:
+        if has_ansible_v219:
+            pytest.exit("ansible_host fixture not supported on Ansible 2.19+")
+
         # assert required --ansible-* parameters were used
         PyTestAnsiblePlugin.assert_required_ansible_parameters(metafunc.config)  # type: ignore[no-untyped-call]
         try:

--- a/src/pytest_ansible/plugin.py
+++ b/src/pytest_ansible/plugin.py
@@ -234,7 +234,7 @@ def pytest_collect_file(
     return None
 
 
-def pytest_generate_tests(metafunc):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201
+def pytest_generate_tests(metafunc):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201, C901
     """Generate tests when specific `ansible_*` fixtures are used by tests.
 
     Raises:
@@ -259,6 +259,9 @@ def pytest_generate_tests(metafunc):  # type: ignore[no-untyped-def]  # noqa: AN
         metafunc.parametrize("ansible_host", iter(hosts[h] for h in hosts))
 
     if "ansible_group" in metafunc.fixturenames:
+        if has_ansible_v219:
+            pytest.exit("ansible_group fixture not supported on Ansible 2.19+")
+
         # assert required --ansible-* parameters were used
         PyTestAnsiblePlugin.assert_required_ansible_parameters(metafunc.config)  # type: ignore[no-untyped-call]
         try:

--- a/src/pytest_ansible/plugin.py
+++ b/src/pytest_ansible/plugin.py
@@ -244,10 +244,12 @@ def warn_or_fail(fixture_name: str) -> None:
         fixture_name: The fixture that has been used.
     """
     if has_ansible_v219:
-        pytest.exit(f"{fixture_name} fixture not supported on Ansible 2.19+")
+        pytest.exit(
+            f"{fixture_name} fixture not supported on Ansible 2.19+. See https://github.com/ansible/pytest-ansible/issues/468."
+        )
     else:
         warnings.warn(
-            f"{fixture_name} fixture is deprecated and will be removed in a future release.",
+            f"{fixture_name} fixture is deprecated and will be removed in a future release. See https://github.com/ansible/pytest-ansible/issues/468.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from pytest_ansible.has_version import has_ansible_v219
 from pytest_ansible.host_manager.utils import get_host_manager
 
 
@@ -173,3 +174,8 @@ def hosts():  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
         return get_host_manager(**kwargs)
 
     return create_host_manager
+
+
+skip_ansible_219 = pytest.mark.skipif(
+    has_ansible_v219, reason="Functionality is unsupported on Ansible 2.19+"
+)

--- a/tests/test_adhoc.py
+++ b/tests/test_adhoc.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import pytest
 
+from .conftest import skip_ansible_219
+
 
 # pylint: disable=unused-import
 try:
@@ -24,7 +26,7 @@ except ImportError:
     EXIT_NOTESTSCOLLECTED = ExitCode.NO_TESTS_COLLECTED
 
 
-@pytest.mark.old
+@skip_ansible_219
 def test_contacted_with_params(pytester, option):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201
     """FIXME."""
     src = """
@@ -54,7 +56,7 @@ def test_contacted_with_params(pytester, option):  # type: ignore[no-untyped-def
     assert result.parseoutcomes()["passed"] == 1
 
 
-@pytest.mark.old
+@skip_ansible_219
 def test_contacted_with_params_and_inventory_marker(pytester, option):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201
     """FIXME."""
     src = f"""
@@ -80,7 +82,7 @@ def test_contacted_with_params_and_inventory_marker(pytester, option):  # type: 
     assert result.parseoutcomes()["passed"] == 1
 
 
-@pytest.mark.old
+@skip_ansible_219
 def test_contacted_with_params_and_host_pattern_marker(pytester, option):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201
     """FIXME."""
     src = """
@@ -111,7 +113,7 @@ def test_contacted_with_params_and_host_pattern_marker(pytester, option):  # typ
     assert result.parseoutcomes()["passed"] == 1
 
 
-@pytest.mark.old
+@skip_ansible_219
 def test_contacted_with_params_and_inventory_host_pattern_marker(pytester, option):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201
     """FIXME."""
     src = f"""
@@ -142,7 +144,7 @@ def test_contacted_with_params_and_inventory_host_pattern_marker(pytester, optio
     assert result.parseoutcomes()["passed"] == 1
 
 
-@pytest.mark.old
+@skip_ansible_219
 def test_become(pytester, option):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201
     """Test --ansible-become* parameters.  This test doesn't actually 'sudo',
     but verifies that 'sudo' was attempted by asserting
@@ -200,7 +202,7 @@ def test_become(pytester, option):  # type: ignore[no-untyped-def]  # noqa: ANN0
     assert result.parseoutcomes()["passed"] == 1
 
 
-@pytest.mark.old
+@skip_ansible_219
 def test_dark_with_params(pytester, option):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201
     """FIXME."""
     src = """
@@ -230,7 +232,7 @@ def test_dark_with_params(pytester, option):  # type: ignore[no-untyped-def]  # 
     assert result.parseoutcomes()["passed"] == 1
 
 
-@pytest.mark.old
+@skip_ansible_219
 def test_dark_with_params_and_inventory_marker(pytester, option):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201
     """FIXME."""
     src = f"""
@@ -256,7 +258,7 @@ def test_dark_with_params_and_inventory_marker(pytester, option):  # type: ignor
     assert result.parseoutcomes()["passed"] == 1
 
 
-@pytest.mark.old
+@skip_ansible_219
 def test_dark_with_params_and_host_pattern_marker(pytester, option):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201
     """FIXME."""
     src = """

--- a/tests/test_adhoc_result.py
+++ b/tests/test_adhoc_result.py
@@ -8,7 +8,7 @@ import pytest
 
 from pytest_ansible.results import ModuleResult
 
-from .conftest import ALL_EXTRA_HOSTS, ALL_HOSTS
+from .conftest import ALL_EXTRA_HOSTS, ALL_HOSTS, skip_ansible_219
 
 
 invalid_hosts = [
@@ -28,6 +28,7 @@ def fixture_adhoc_result(request, hosts):  # type: ignore[no-untyped-def]  # noq
     return create_hosts
 
 
+@skip_ansible_219
 def test_len(adhoc_result):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201, D103
     adhoc_result_ret, include_extra_inv = adhoc_result()
     assert len(adhoc_result_ret) == len(ALL_HOSTS) + len(
@@ -35,6 +36,7 @@ def test_len(adhoc_result):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN
     )
 
 
+@skip_ansible_219
 def test_keys(adhoc_result):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201, D103
     adhoc_result_ret, include_extra_inv = adhoc_result()
     assert set(adhoc_result_ret) == set(
@@ -42,6 +44,7 @@ def test_keys(adhoc_result):  # type: ignore[no-untyped-def]  # noqa: ANN001, AN
     )
 
 
+@skip_ansible_219
 def test_items(adhoc_result):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201, D103
     adhoc_result_ret, include_extra_inv = adhoc_result()
     items = adhoc_result_ret.items()
@@ -54,6 +57,7 @@ def test_items(adhoc_result):  # type: ignore[no-untyped-def]  # noqa: ANN001, A
     assert count == len(ALL_HOSTS + (ALL_EXTRA_HOSTS if include_extra_inv else []))
 
 
+@skip_ansible_219
 def test_values(adhoc_result):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201, D103
     adhoc_result_ret, include_extra_inv = adhoc_result()
     values = adhoc_result_ret.values()
@@ -67,6 +71,7 @@ def test_values(adhoc_result):  # type: ignore[no-untyped-def]  # noqa: ANN001, 
 
 
 @pytest.mark.parametrize("host", ALL_HOSTS + ALL_EXTRA_HOSTS)
+@skip_ansible_219
 def test_contains(adhoc_result, host):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201, D103
     adhoc_result_ret, include_extra_inv = adhoc_result()
     if not include_extra_inv and host in ALL_EXTRA_HOSTS:
@@ -76,12 +81,14 @@ def test_contains(adhoc_result, host):  # type: ignore[no-untyped-def]  # noqa: 
 
 
 @pytest.mark.parametrize("host", invalid_hosts)
+@skip_ansible_219
 def test_not_contains(adhoc_result, host):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201, D103
     adhoc_result_ret, dummy = adhoc_result()
     assert host not in adhoc_result_ret
 
 
 @pytest.mark.parametrize("host_pattern", ALL_HOSTS + ALL_EXTRA_HOSTS)
+@skip_ansible_219
 def test_getitem(adhoc_result, host_pattern):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201, D103
     adhoc_result_ret, include_extra_inv = adhoc_result()
     if not include_extra_inv and host_pattern in ALL_EXTRA_HOSTS:
@@ -93,6 +100,7 @@ def test_getitem(adhoc_result, host_pattern):  # type: ignore[no-untyped-def]  #
 
 
 @pytest.mark.parametrize("host_pattern", invalid_hosts)
+@skip_ansible_219
 def test_not_getitem(adhoc_result, host_pattern):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201, D103
     adhoc_result_ret, dummy = adhoc_result()
     with pytest.raises(KeyError):
@@ -100,6 +108,7 @@ def test_not_getitem(adhoc_result, host_pattern):  # type: ignore[no-untyped-def
 
 
 @pytest.mark.parametrize("host_pattern", ALL_HOSTS + ALL_EXTRA_HOSTS)
+@skip_ansible_219
 def test_getattr(adhoc_result, host_pattern):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201, D103
     adhoc_result_ret, include_extra_inv = adhoc_result()
     if not include_extra_inv and host_pattern in ALL_EXTRA_HOSTS:
@@ -110,6 +119,7 @@ def test_getattr(adhoc_result, host_pattern):  # type: ignore[no-untyped-def]  #
 
 
 @pytest.mark.parametrize("host_pattern", invalid_hosts)
+@skip_ansible_219
 def test_not_getattr(adhoc_result, host_pattern):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201, D103
     adhoc_result_ret, dummy = adhoc_result()
     assert not hasattr(adhoc_result_ret, host_pattern)
@@ -118,6 +128,7 @@ def test_not_getattr(adhoc_result, host_pattern):  # type: ignore[no-untyped-def
 
 
 @pytest.mark.requires_ansible_v2
+@skip_ansible_219
 def test_connection_failure_v2():  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
     from pytest_ansible.errors import AnsibleConnectionFailure
     from pytest_ansible.host_manager.utils import get_host_manager
@@ -142,6 +153,7 @@ def test_connection_failure_v2():  # type: ignore[no-untyped-def]  # noqa: ANN20
 
 
 @pytest.mark.requires_ansible_v2
+@skip_ansible_219
 def test_connection_failure_extra_inventory_v2():  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
     from pytest_ansible.errors import AnsibleConnectionFailure
     from pytest_ansible.host_manager.utils import get_host_manager

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from .conftest import skip_ansible_219
+
 
 try:
     from _pytest.main import EXIT_OK  # type: ignore  # noqa: PGH003
@@ -34,6 +36,7 @@ def test_ansible_adhoc(pytester, option):  # type: ignore[no-untyped-def]  # noq
     assert result.parseoutcomes()["passed"] == 1
 
 
+@skip_ansible_219
 def test_ansible_module(pytester, option):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201, D103
     src = """
         import pytest
@@ -55,6 +58,7 @@ def test_ansible_module(pytester, option):  # type: ignore[no-untyped-def]  # no
     assert result.parseoutcomes()["passed"] == 1
 
 
+@skip_ansible_219
 def test_ansible_facts(pytester, option):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201, D103
     src = """
         import pytest
@@ -76,6 +80,7 @@ def test_ansible_facts(pytester, option):  # type: ignore[no-untyped-def]  # noq
     assert result.parseoutcomes()["passed"] == 1
 
 
+@skip_ansible_219
 def test_localhost(pytester, option):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201, D103
     src = """
         import pytest

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -6,8 +6,11 @@ from typing import Any
 
 import pytest
 
+from .conftest import skip_ansible_219
+
 
 @pytest.mark.ansible(inventory="local,", connection="local", host_pattern="all")
+@skip_ansible_219
 def test_func(ansible_module: Any) -> None:  # noqa: ANN401
     """Sample test for ansible module.
 

--- a/tests/test_host_manager.py
+++ b/tests/test_host_manager.py
@@ -25,6 +25,7 @@ pytestmark = [
     "include_extra_inventory",
     (True, False),
 )
+@skip_ansible_219
 def test_host_manager_len(hosts, include_extra_inventory):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201, D103
     _hosts = hosts(include_extra_inventory=include_extra_inventory)
     assert len(_hosts) == len(ALL_HOSTS) + len(
@@ -36,6 +37,7 @@ def test_host_manager_len(hosts, include_extra_inventory):  # type: ignore[no-un
     "include_extra_inventory",
     (True, False),
 )
+@skip_ansible_219
 def test_host_manager_keys(hosts, include_extra_inventory):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201, D103
     _hosts = hosts(include_extra_inventory=include_extra_inventory)
     sorted_keys = _hosts.keys()
@@ -121,6 +123,7 @@ def test_host_manager_not_getitem(  # type: ignore[no-untyped-def]  # noqa: ANN2
     "include_extra_inventory",
     (True, False),
 )
+@skip_ansible_219
 def test_host_manager_getattr(host_pattern, num_hosts, hosts, include_extra_inventory):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201, ARG001, D103
     _hosts = hosts(include_extra_inventory=include_extra_inventory)
     if not include_extra_inventory and host_pattern.startswith("extra"):
@@ -137,6 +140,7 @@ def test_host_manager_getattr(host_pattern, num_hosts, hosts, include_extra_inve
     "include_extra_inventory",
     (True, False),
 )
+@skip_ansible_219
 def test_host_manager_slice(host_slice, num_hosts, hosts, include_extra_inventory):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201, D103
     _hosts = hosts(include_extra_inventory=include_extra_inventory)
     assert len(_hosts[host_slice]) == num_hosts[include_extra_inventory], (
@@ -167,6 +171,7 @@ def test_host_manager_not_slice(host_slice, hosts, include_extra_inventory):  # 
     "include_extra_inventory",
     (True, False),
 )
+@skip_ansible_219
 def test_host_manager_not_getattr(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
     host_pattern,  # noqa: ANN001
     num_hosts,  # noqa: ANN001, ARG001

--- a/tests/test_host_manager.py
+++ b/tests/test_host_manager.py
@@ -12,6 +12,7 @@ from .conftest import (
     NEGATIVE_HOST_SLICES,
     POSITIVE_HOST_PATTERNS,
     POSITIVE_HOST_SLICES,
+    skip_ansible_219,
 )
 
 
@@ -51,6 +52,7 @@ def test_host_manager_keys(hosts, include_extra_inventory):  # type: ignore[no-u
     "include_extra_inventory",
     (True, False),
 )
+@skip_ansible_219
 def test_host_manager_contains(host_pattern, num_hosts, hosts, include_extra_inventory):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201, ARG001, D103
     _hosts = hosts(include_extra_inventory=include_extra_inventory)
     if not include_extra_inventory and host_pattern.startswith("extra"):
@@ -64,6 +66,7 @@ def test_host_manager_contains(host_pattern, num_hosts, hosts, include_extra_inv
     NEGATIVE_HOST_PATTERNS,
 )
 @pytest.mark.parametrize("include_extra_inventory", (True, False))
+@skip_ansible_219
 def test_host_manager_not_contains(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
     host_pattern,  # noqa: ANN001
     num_hosts,  # noqa: ANN001, ARG001
@@ -82,6 +85,7 @@ def test_host_manager_not_contains(  # type: ignore[no-untyped-def]  # noqa: ANN
     "include_extra_inventory",
     (True, False),
 )
+@skip_ansible_219
 def test_host_manager_getitem(host_pattern, num_hosts, hosts, include_extra_inventory):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201, ARG001, D103
     _hosts = hosts(include_extra_inventory=include_extra_inventory)
     if not include_extra_inventory and host_pattern.startswith("extra"):

--- a/tests/test_module_dispatcher.py
+++ b/tests/test_module_dispatcher.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from .conftest import NEGATIVE_HOST_PATTERNS, POSITIVE_HOST_PATTERNS
+from .conftest import NEGATIVE_HOST_PATTERNS, POSITIVE_HOST_PATTERNS, skip_ansible_219
 
 
 def test_type_error() -> None:
@@ -30,6 +30,7 @@ def test_importerror_requires_v1():  # type: ignore[no-untyped-def]  # noqa: ANN
     "include_extra_inventory",
     (True, False),
 )
+@skip_ansible_219
 def test_dispatcher_len(host_pattern, num_hosts, hosts, include_extra_inventory):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201, D103
     hosts = hosts(include_extra_inventory=include_extra_inventory)
     assert len(getattr(hosts, host_pattern)) == num_hosts[include_extra_inventory]
@@ -43,6 +44,7 @@ def test_dispatcher_len(host_pattern, num_hosts, hosts, include_extra_inventory)
     "include_extra_inventory",
     (True, False),
 )
+@skip_ansible_219
 def test_dispatcher_contains(host_pattern, num_hosts, hosts, include_extra_inventory):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201, ARG001, D103
     hosts = hosts(include_extra_inventory=include_extra_inventory)
     assert host_pattern in hosts["all"]
@@ -53,6 +55,7 @@ def test_dispatcher_contains(host_pattern, num_hosts, hosts, include_extra_inven
     "include_extra_inventory",
     (True, False),
 )
+@skip_ansible_219
 def test_dispatcher_not_contains(  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
     host_pattern,  # noqa: ANN001
     num_hosts,  # noqa: ANN001, ARG001

--- a/tests/test_module_dispatcher.py
+++ b/tests/test_module_dispatcher.py
@@ -66,6 +66,7 @@ def test_dispatcher_not_contains(  # type: ignore[no-untyped-def]  # noqa: ANN20
     assert host_pattern not in hosts["all"]
 
 
+@skip_ansible_219
 def test_ansible_module_error(hosts):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201
     """Verify that AnsibleModuleError is raised when no such module exists."""
     from pytest_ansible.errors import AnsibleModuleError

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -129,6 +129,7 @@ def test_param_requires_value(pytester, required_value_parameter):  # type: igno
 
 
 @pytest.mark.requires_ansible_v2
+@skip_ansible_219
 def test_params_required_without_inventory_with_host_pattern_v2(pytester, option):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201, D103
     src = """
         import pytest

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import ansible
 import pytest
 
+from .conftest import skip_ansible_219
+
 
 # pylint: disable=unused-import
 try:
@@ -86,6 +88,7 @@ def test_params_not_required_when_not_using_fixture(pytester, option):  # type: 
         "ansible_facts",
     ),
 )
+@skip_ansible_219
 def test_params_required_when_using_fixture(pytester, option, fixture_name):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201
     """Verify that ansible parameters are not required if the fixture is used."""
     src = f"""
@@ -137,6 +140,7 @@ def test_params_required_without_inventory_with_host_pattern_v2(pytester, option
     assert result.ret == EXIT_OK
 
 
+@skip_ansible_219
 def test_param_override_with_marker(pytester, option):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201, D103
     src = """
         import pytest

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -83,6 +83,7 @@ def test_pytest_generate_tests_with_ansible_host():  # type: ignore[no-untyped-d
     assert metafunc.parametrize.call_count == 1
 
 
+@skip_ansible_219
 def test_pytest_generate_tests_with_ansible_group():  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
     metafunc = MagicMock()
     metafunc.fixturenames = ["ansible_group"]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -7,6 +7,8 @@ from unittest.mock import MagicMock
 
 from pytest_ansible.plugin import PyTestAnsiblePlugin, pytest_generate_tests
 
+from .conftest import skip_ansible_219
+
 
 class MockItem:
     """Mock class for item object."""
@@ -57,6 +59,7 @@ class MockMetafunc:
         self.parametrize = MagicMock()
 
 
+@skip_ansible_219
 def test_pytest_generate_tests_with_ansible_host():  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
     metafunc = MagicMock()
     metafunc.fixturenames = ["ansible_host"]


### PR DESCRIPTION
- [x] Add here list of deprecated things
  - `ansible_host` fixture
  - `ansible_group` fixture
- [x] Raise DeprecatedWarning exceptions when these are used, so people will know that they are going away.