### PR TITLE
Add typing-extensions as a runtime dependency

### DIFF
--- a/.config/constraints.txt
+++ b/.config/constraints.txt
@@ -6,10 +6,10 @@ attrs==25.3.0             # via jsonschema, referencing
 babel==2.17.0             # via mkdocs-material
 backrefs==5.9             # via mkdocs-material
 beautifulsoup4==4.13.4    # via linkchecker, mkdocs-htmlproofer-plugin
-bracex==2.6         # via wcmatch
+bracex==2.6               # via wcmatch
 cachetools==6.1.0         # via tox
 cairocffi==1.7.1          # via cairosvg
-cairosvg==2.8.2           # via mkdocs-ansible
+cairosvg==2.7.1           # via mkdocs-ansible
 certifi==2025.6.15        # via requests
 cffi==1.17.1              # via cairocffi, cryptography
 cfgv==3.4.0               # via pre-commit
@@ -52,8 +52,8 @@ markupsafe==3.0.2         # via jinja2, mkdocs, mkdocs-autorefs, mkdocstrings
 mccabe==0.7.0             # via pylint
 mdurl==0.1.2              # via markdown-it-py
 mergedeep==1.3.4          # via mkdocs, mkdocs-get-deps
-mkdocs==1.6.1             # via mkdocs-ansible, mkdocs-autorefs, mkdocs-gen-files, mkdocs-htmlproofer-plugin, mkdocs-macros-plugin, mkdocs-material, mkdocs-minify-plugin, mkdocs-monorepo-plugin, mkdocstrings
-mkdocs-ansible==25.2.0    # via pytest-ansible (pyproject.toml)
+mkdocs==1.6.1             # via mkdocs-ansible, mkdocs-autorefs, mkdocs-gen-files, mkdocs-htmlproofer-plugin, mkdocs-macros-plugin, mkdocs-material, mkdocs-minify-plugin, mkdocstrings
+mkdocs-ansible==25.5.0    # via pytest-ansible (pyproject.toml)
 mkdocs-autorefs==1.4.2    # via mkdocstrings, mkdocstrings-python
 mkdocs-gen-files==0.5.0   # via mkdocs-ansible
 mkdocs-get-deps==0.2.0    # via mkdocs
@@ -62,7 +62,6 @@ mkdocs-macros-plugin==1.3.7  # via mkdocs-ansible
 mkdocs-material==9.6.14   # via mkdocs-ansible
 mkdocs-material-extensions==1.3.1  # via mkdocs-ansible, mkdocs-material
 mkdocs-minify-plugin==0.8.0  # via mkdocs-ansible
-mkdocs-monorepo-plugin==1.1.2  # via mkdocs-ansible
 mkdocstrings==0.29.1      # via mkdocs-ansible, mkdocstrings-python
 mkdocstrings-python==1.16.12  # via mkdocs-ansible
 molecule==25.6.0          # via pytest-ansible (pyproject.toml)
@@ -71,14 +70,14 @@ mypy-extensions==1.1.0    # via mypy
 nodeenv==1.9.1            # via pre-commit
 packaging==25.0           # via ansible-compat, ansible-core, mkdocs, mkdocs-macros-plugin, molecule, pyproject-api, pytest, tox, pytest-ansible (pyproject.toml)
 paginate==0.5.7           # via mkdocs-material
-pathspec==0.12.1          # via mkdocs, mkdocs-macros-plugin
+pathspec==0.12.1          # via mkdocs, mkdocs-macros-plugin, mypy
 pillow==11.2.1            # via cairosvg, mkdocs-ansible
 platformdirs==4.3.8       # via mkdocs-get-deps, pylint, tox, virtualenv
 pluggy==1.6.0             # via molecule, pytest, tox
 pre-commit==4.2.0         # via pytest-ansible (pyproject.toml)
 pycparser==2.22           # via cffi
 pydoclint==0.6.6          # via pytest-ansible (pyproject.toml)
-pygments==2.19.2          # via mkdocs-material, rich
+pygments==2.19.2          # via mkdocs-material, pytest, rich
 pylint==3.3.7             # via pytest-ansible (pyproject.toml)
 pymdown-extensions==10.16  # via markdown-exec, mkdocs-ansible, mkdocs-material, mkdocstrings
 pyproject-api==1.9.1      # via tox
@@ -87,7 +86,6 @@ pytest-github-actions-annotate-failures==0.3.0  # via pytest-ansible (pyproject.
 pytest-plus==0.8.1        # via pytest-ansible (pyproject.toml)
 pytest-xdist==3.7.0       # via pytest-ansible (pyproject.toml)
 python-dateutil==2.9.0.post0  # via ghp-import, mkdocs-macros-plugin
-python-slugify==8.0.4     # via mkdocs-monorepo-plugin
 pyyaml==6.0.2             # via ansible-compat, ansible-core, mkdocs, mkdocs-get-deps, mkdocs-macros-plugin, molecule, pre-commit, pymdown-extensions, pyyaml-env-tag
 pyyaml-env-tag==1.1       # via mkdocs
 referencing==0.36.2       # via jsonschema, jsonschema-specifications
@@ -100,7 +98,6 @@ soupsieve==2.7            # via beautifulsoup4
 subprocess-tee==0.4.2     # via ansible-compat
 super-collections==0.5.3  # via mkdocs-macros-plugin
 termcolor==3.1.0          # via mkdocs-macros-plugin
-text-unidecode==1.3       # via python-slugify
 tinycss2==1.4.0           # via cairosvg, cssselect2
 toml-sort==0.24.2         # via pytest-ansible (pyproject.toml)
 tomli==2.2.1              # via coverage, mypy, pydoclint, pylint, pyproject-api, pytest, tox

--- a/.config/requirements.in
+++ b/.config/requirements.in
@@ -2,3 +2,4 @@ ansible-core>=2.14
 ansible-compat>=4.1.11
 pytest>=6
 packaging
+typing-extensions

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
           )$
 
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.6.1
+    rev: v3.6.2
     hooks:
       - id: prettier
         always_run: true
@@ -48,7 +48,7 @@ repos:
       - id: tox-ini-fmt
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.12
+    rev: v0.12.1
     hooks:
       - id: ruff
         args:
@@ -87,7 +87,7 @@ repos:
           - setuptools
 
   - repo: https://github.com/pre-commit/mirrors-mypy.git
-    rev: v1.16.0
+    rev: v1.16.1
     hooks:
       - id: mypy
         additional_dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,7 +342,8 @@ target-version = "py310"
 [tool.ruff.lint]
 ignore = [
   "COM812", # conflicts with ISC001 on format
-  "ISC001" # conflicts with COM812 on format
+  "ISC001", # conflicts with COM812 on format
+  "PLC0415" # import should be at the top-level of a file
 ]
 select = ["ALL"]
 


### PR DESCRIPTION
This PR adds `typing-extensions` as a runtime dependency and update the other deps as well.

Fixes: https://github.com/ansible/pytest-ansible/issues/470