### PR TITLE
Avoid logging spam during collection phase

### DIFF
--- a/src/pytest_ansible/plugin.py
+++ b/src/pytest_ansible/plugin.py
@@ -249,7 +249,8 @@ def pytest_configure(config):  # type: ignore[no-untyped-def]  # noqa: ANN001, A
         inject_only()
     else:
         start_path = config.invocation_params.dir
-        inject(start_path)
+        if (start_path / "galaxy.yml").exists():
+            inject(start_path)
 
     # register an additional marker
     config.addinivalue_line("markers", "no_driver: molecule test that uses no driver")


### PR DESCRIPTION
As pytest_configure runs for each thread, it has the potential to spam the console with repeated messages when pytest-xdist is installed.

This change will avoid such messages related to missing collection galaxy.yml file.