### PR TITLE
chore: fix for abnormally low coverage reports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ branch = true
 # CoverageWarning: Couldn't use data file ... database disk image is malformed
 # concurrency = ["multiprocessing"] # , "thread"]
 omit = ["_version.py"]
-parallel = false
+parallel = true
 source = ["src"]
 
 [tool.mypy]


### PR DESCRIPTION
Tests are tripping over each other writing to the .coverage file and so coverage gets dropped with a `sqlite3.OperationalError: table coverage_schema already exists`

Enabling parallel lets them write to individual coverage files which we already try to combine int `tools/report_coverage`

~~Alternatively, removing `-n auto` also solves the issue~~