### PR TITLE
fix: add missing ansible-compat dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ classifiers = [
 ]
 dependencies = [
   "ansible-core>=2.17.14",
+  "ansible-compat>=25.8.2",
   "cffi>=1.17.1",
   "packaging>=25.0",
   "pytest>=6",

--- a/uv.lock
+++ b/uv.lock
@@ -1790,6 +1790,7 @@ wheels = [
 name = "pytest-ansible"
 source = { editable = "." }
 dependencies = [
+    { name = "ansible-compat" },
     { name = "ansible-core", version = "2.17.14", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "ansible-core", version = "2.19.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "cffi" },
@@ -1842,6 +1843,7 @@ pkg = [
 
 [package.metadata]
 requires-dist = [
+    { name = "ansible-compat", specifier = ">=25.8.2" },
     { name = "ansible-core", specifier = ">=2.17.14" },
     { name = "cffi", specifier = ">=1.17.1" },
     { name = "packaging", specifier = ">=25.0" },


### PR DESCRIPTION
##### SUMMARY
Installing the latest release of `pytest-ansible` (`25.11.0`) through `pip install` results in installation with missing dependencies (namely `ansible-compat`).

Current pytest executions return the following stacktrace:
```
  File ".../python3.11/site-packages/pytest_ansible/molecule.py", line 19, in <module>
    from ansible_compat.config import ansible_version
ModuleNotFoundError: No module named 'ansible_compat' 
```

Installing the `ansible-compat` package manually resolves the issue. Looks like the `ansible-compat` dependency was removed after the adoption of the `uv.lock`
https://github.com/ansible/pytest-ansible/blob/main/pyproject.toml#L66

##### ISSUE TYPE
 - Bug