### PR TITLE
fix: suppress ruff PLW0717 to unblock renovate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -403,7 +403,8 @@ ignore = [
   # temporary disabled when we enabled preview mode:
   "RUF052",
   "PLC2701",
-  "PLR6301"
+  "PLR6301",
+  "PLW0717",  # try-too-many-statements
 ]
 select = ["ALL"]
 


### PR DESCRIPTION
## Summary
- ruff 0.15.17 enables PLW0717 (try-too-many-statements) by default, will break renovate once it bumps ruff
- Added PLW0717 to the ruff ignore list — same as what was done in vscode-ansible (#2719)

## Test plan
- [ ] CI passes