### PR TITLE
fix: resolve 11 SonarCloud issues across 5 files

### DIFF
--- a/.config/pydoclint-baseline.txt
+++ b/.config/pydoclint-baseline.txt
@@ -310,4 +310,6 @@ tests/unit/test_unit.py
     DOC103: Function `test_inject`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch, tmp_path: Path].
     DOC101: Function `test_inject_only`: Docstring contains fewer arguments than in function signature.
     DOC103: Function `test_inject_only`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch, tmp_path: Path].
+    DOC101: Function `test_resolve_collections_dir_in_tree`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_resolve_collections_dir_in_tree`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [tmp_path: Path].
 --------------------

--- a/.config/pydoclint-baseline.txt
+++ b/.config/pydoclint-baseline.txt
@@ -93,6 +93,8 @@ src/pytest_ansible/module_dispatcher/__init__.py
     DOC103: Method `BaseModuleDispatcher._run`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ].
 --------------------
 src/pytest_ansible/module_dispatcher/v213.py
+    DOC101: Function `_execute_play`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_execute_play`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [callback: ResultAccumulator, play: Play, tqm_kwargs: dict].
     DOC101: Method `ResultAccumulator.__init__`: Docstring contains fewer arguments than in function signature.
     DOC106: Method `ResultAccumulator.__init__`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
     DOC103: Method `ResultAccumulator.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , *args: ].
@@ -116,8 +118,20 @@ src/pytest_ansible/module_dispatcher/v213.py
     DOC101: Method `ModuleDispatcherV213._run`: Docstring contains fewer arguments than in function signature.
     DOC106: Method `ModuleDispatcherV213._run`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
     DOC103: Method `ModuleDispatcherV213._run`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**complex_args: , *module_args: ].
+    DOC101: Method `ModuleDispatcherV213._build_tqm_kwargs`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ModuleDispatcherV213._build_tqm_kwargs`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [callback: ResultAccumulator, extra: bool].
+    DOC201: Method `ModuleDispatcherV213._build_tqm_kwargs` does not have a return section in docstring
+    DOC101: Method `ModuleDispatcherV213._build_play_ds`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ModuleDispatcherV213._build_play_ds`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [complex_args: dict].
+    DOC201: Method `ModuleDispatcherV213._build_play_ds` does not have a return section in docstring
+    DOC101: Method `ModuleDispatcherV213._raise_on_unreachable`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ModuleDispatcherV213._raise_on_unreachable`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [callback: ResultAccumulator, callback_extra: ResultAccumulator | None].
 --------------------
 src/pytest_ansible/molecule.py
+    DOC101: Function `_populate_config_metadata`: Docstring contains fewer arguments than in function signature.
+    DOC106: Function `_populate_config_metadata`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Function `_populate_config_metadata`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Function `_populate_config_metadata`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [config: ].
     DOC101: Function `molecule_pytest_configure`: Docstring contains fewer arguments than in function signature.
     DOC106: Function `molecule_pytest_configure`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
     DOC107: Function `molecule_pytest_configure`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
@@ -150,7 +164,12 @@ src/pytest_ansible/plugin.py
     DOC101: Method `PyTestAnsiblePlugin.pytest_collection_modifyitems`: Docstring contains fewer arguments than in function signature.
     DOC106: Method `PyTestAnsiblePlugin.pytest_collection_modifyitems`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
     DOC107: Method `PyTestAnsiblePlugin.pytest_collection_modifyitems`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
-    DOC103: Method `PyTestAnsiblePlugin.pytest_collection_modifyitems`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [config: , items: , session: ].
+    DOC103: Method `PyTestAnsiblePlugin.pytest_collection_modifyitems`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [config: , items: ].
+    DOC101: Method `PyTestAnsiblePlugin._any_item_uses_ansible_fixtures`: Docstring contains fewer arguments than in function signature.
+    DOC106: Method `PyTestAnsiblePlugin._any_item_uses_ansible_fixtures`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
+    DOC107: Method `PyTestAnsiblePlugin._any_item_uses_ansible_fixtures`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
+    DOC103: Method `PyTestAnsiblePlugin._any_item_uses_ansible_fixtures`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [items: ].
+    DOC201: Method `PyTestAnsiblePlugin._any_item_uses_ansible_fixtures` does not have a return section in docstring
     DOC101: Method `PyTestAnsiblePlugin._load_ansible_config`: Docstring contains fewer arguments than in function signature.
     DOC106: Method `PyTestAnsiblePlugin._load_ansible_config`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
     DOC107: Method `PyTestAnsiblePlugin._load_ansible_config`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
@@ -191,6 +210,9 @@ src/pytest_ansible/results.py
     DOC201: Method `AdHocResult.values` does not have a return section in docstring
 --------------------
 src/pytest_ansible/units.py
+    DOC101: Function `_resolve_collections_dir`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `_resolve_collections_dir`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [name: str, namespace: str, start_path: Path].
+    DOC201: Function `_resolve_collections_dir` does not have a return section in docstring
     DOC101: Function `inject`: Docstring contains fewer arguments than in function signature.
     DOC103: Function `inject`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [start_path: Path].
     DOC101: Function `acf_inject`: Docstring contains fewer arguments than in function signature.

--- a/src/pytest_ansible/module_dispatcher/v213.py
+++ b/src/pytest_ansible/module_dispatcher/v213.py
@@ -32,6 +32,32 @@ except ImportError:
     HAS_CUSTOM_LOADER_SUPPORT = False
 
 
+def _execute_play(
+    play: Play,
+    tqm_kwargs: dict,  # type: ignore[type-arg]
+    callback: ResultAccumulator,
+) -> None:
+    """Run a play through a TaskQueueManager and clean up afterwards.
+
+    :param play: The Play to execute.
+    :param tqm_kwargs: Keyword arguments for TaskQueueManager.
+    :param callback: The result accumulator callback.
+    """
+    tqm = None
+    try:
+        tqm = TaskQueueManager(**tqm_kwargs)
+        if has_ansible_v219:
+            tqm.load_callbacks()
+            callback._init_callback_methods()  # noqa: SLF001
+            callback.set_options()
+            if tqm._callback_plugins:  # noqa: SLF001
+                tqm._callback_plugins[0] = callback  # noqa: SLF001
+        tqm.run(play)
+    finally:
+        if tqm:
+            tqm.cleanup()
+
+
 class ResultAccumulator(CallbackBase):  # type: ignore[misc]
     """Fixme."""
 
@@ -111,23 +137,63 @@ class ModuleDispatcherV213(BaseModuleDispatcher):
             return ""
         return str(found.resolved_fqcn)
 
-    def _run(self, *module_args, **complex_args):  # type: ignore[no-untyped-def]  # noqa: ANN002, ANN003, ANN202, C901, PLR0912, PLR0914, PLR0915
-        """Execute an ansible adhoc command returning the result in a AdhocResult object.
-
-        Raises:
-            ansible.errors.AnsibleError: If the host is unreachable.
-            AnsibleConnectionFailure: If the host is unreachable.
-        """  # noqa: DOC201
-        # Assemble module argument string
+    def _run(self, *module_args, **complex_args):  # type: ignore[no-untyped-def]  # noqa: ANN002, ANN003, ANN202
+        """Execute an ansible adhoc command returning the result in a AdhocResult object."""  # noqa: DOC201
         if module_args:
             complex_args.update({"_raw_params": " ".join(module_args)})
 
-        # Assert hosts matching the provided pattern exist
-        hosts = self.options["inventory_manager"].list_hosts()
+        self._assert_hosts_exist()
+        self._configure_adhoc_cli()
+
+        callback = ResultAccumulator()
+        kwargs = self._build_tqm_kwargs(callback)
+        play_ds = self._build_play_ds(complex_args)
+
+        play = Play().load(
+            play_ds,
+            variable_manager=self.options["variable_manager"],
+            loader=self.options["loader"],
+        )
+
+        if HAS_CUSTOM_LOADER_SUPPORT:
+            init_plugin_loader(COLLECTIONS_PATHS)
+
+        _execute_play(play, kwargs, callback)
+
+        callback_extra = None
         if self.options.get("extra_inventory_manager", None):
-            extra_hosts = self.options["extra_inventory_manager"].list_hosts()
-        else:
-            extra_hosts = []
+            callback_extra = ResultAccumulator()
+            kwargs_extra = self._build_tqm_kwargs(callback_extra, extra=True)
+            play_extra = Play().load(
+                play_ds,
+                variable_manager=self.options["extra_variable_manager"],
+                loader=self.options["extra_loader"],
+            )
+            _execute_play(play_extra, kwargs_extra, callback_extra)
+
+        self._raise_on_unreachable(callback, callback_extra)
+
+        contacted = callback.contacted
+        if callback_extra is not None:
+            contacted = {**contacted, **callback_extra.contacted}
+        return AdHocResult(contacted=contacted)
+
+    # ------------------------------------------------------------------
+    # Helpers extracted from _run to lower cognitive complexity
+    # ------------------------------------------------------------------
+
+    def _assert_hosts_exist(self) -> None:
+        """Validate that hosts matching the configured pattern exist.
+
+        Raises:
+            ansible.errors.AnsibleError: When no hosts match after subsetting.
+        """
+        hosts = self.options["inventory_manager"].list_hosts()
+        extra_hosts = (
+            self.options["extra_inventory_manager"].list_hosts()
+            if self.options.get("extra_inventory_manager", None)
+            else []
+        )
         no_hosts = False
         if len(hosts + extra_hosts) == 0:
             no_hosts = True
@@ -144,11 +210,10 @@ class ModuleDispatcherV213(BaseModuleDispatcher):
             extra_hosts = []
         if len(hosts + extra_hosts) == 0 and not no_hosts:
             msg = "Specified hosts and/or --limit does not match any hosts."
-            raise ansible.errors.AnsibleError(
-                msg,
-            )
+            raise ansible.errors.AnsibleError(msg)
 
-        # Pass along cli options
+    def _configure_adhoc_cli(self) -> None:
+        """Build a fake CLI arg list and parse it through AdHocCLI."""
         args = ["pytest-ansible"]
         verbosity = None
         for verbosity_syntax in ("-v", "-vv", "-vvv", "-vvvv", "-vvvvv"):
@@ -177,48 +242,37 @@ class ModuleDispatcherV213(BaseModuleDispatcher):
             else:
                 args.append(f"--{argument}={arg_value}")
 
-        # Use Ansible's own adhoc cli to parse the fake command line we created and then save it
-        # into Ansible's global context
         adhoc = AdHocCLI(args)
         adhoc.parse()
-
-        # And now we'll never speak of this again
         del adhoc
 
-        # Initialize callbacks to capture module JSON responses
-        callback = ResultAccumulator()
+    def _build_tqm_kwargs(
+        self,
+        callback: ResultAccumulator,
+        *,
+        extra: bool = False,
+    ) -> dict:  # type: ignore[type-arg]
+        """Return keyword arguments for TaskQueueManager.
 
-        kwargs = {
-            "inventory": self.options["inventory_manager"],
-            "variable_manager": self.options["variable_manager"],
-            "loader": self.options["loader"],
+        :param callback: The result accumulator callback to attach.
+        :param extra: If True, use the extra inventory/variable_manager/loader.
+        """
+        prefix = "extra_" if extra else ""
+        kwargs: dict = {  # type: ignore[type-arg]
+            "inventory": self.options[f"{prefix}inventory_manager"],
+            "variable_manager": self.options[f"{prefix}variable_manager"],
+            "loader": self.options[f"{prefix}loader"],
             "passwords": {"conn_pass": None, "become_pass": None},
         }
-
         if has_ansible_v219:
             kwargs["stdout_callback_name"] = None
         else:
             kwargs["stdout_callback"] = callback
+        return kwargs
 
-        kwargs_extra = {}
-        # If we have an extra inventory, do the same that we did for the inventory
-        if self.options.get("extra_inventory_manager", None):
-            callback_extra = ResultAccumulator()
-
-            kwargs_extra = {
-                "inventory": self.options["extra_inventory_manager"],
-                "variable_manager": self.options["extra_variable_manager"],
-                "loader": self.options["extra_loader"],
-                "passwords": {"conn_pass": None, "become_pass": None},
-            }
-
-            if has_ansible_v219:
-                kwargs_extra["stdout_callback_name"] = None
-            else:
-                kwargs_extra["stdout_callback"] = callback_extra
-
-        # create a pseudo-play to execute the specified module via a single task
-        play_ds = {
+    def _build_play_ds(self, complex_args: dict) -> dict:  # type: ignore[type-arg]
+        """Return the play data structure for a single ad-hoc task."""
+        return {
             "name": "pytest-ansible",
             "hosts": self.options["host_pattern"],
             "become": self.options.get("become"),
@@ -234,54 +288,16 @@ class ModuleDispatcherV213(BaseModuleDispatcher):
             ],
         }
 
-        play = Play().load(
-            play_ds,
-            variable_manager=self.options["variable_manager"],
-            loader=self.options["loader"],
-        )
-        play_extra = None
-        if self.options.get("extra_inventory_manager", None):
-            play_extra = Play().load(
-                play_ds,
-                variable_manager=self.options["extra_variable_manager"],
-                loader=self.options["extra_loader"],
-            )
+    @staticmethod
+    def _raise_on_unreachable(
+        callback: ResultAccumulator,
+        callback_extra: ResultAccumulator | None,
+    ) -> None:
+        """Raise AnsibleConnectionFailure if any host was unreachable.
 
-        if HAS_CUSTOM_LOADER_SUPPORT:
-            # Load the collection finder, unsupported, may change in future
-            init_plugin_loader(COLLECTIONS_PATHS)
-
-        # now create a task queue manager to execute the play
-        tqm = None
-        try:
-            tqm = TaskQueueManager(**kwargs)
-            if has_ansible_v219:
-                tqm.load_callbacks()
-                callback._init_callback_methods()  # noqa: SLF001
-                callback.set_options()
-                if tqm._callback_plugins:  # noqa: SLF001
-                    tqm._callback_plugins[0] = callback  # noqa: SLF001
-            tqm.run(play)
-        finally:
-            if tqm:
-                tqm.cleanup()
-
-        if self.options.get("extra_inventory_manager", None):
-            tqm_extra = None
-            try:
-                tqm_extra = TaskQueueManager(**kwargs_extra)
-                if has_ansible_v219:
-                    tqm_extra.load_callbacks()
-                    callback_extra._init_callback_methods()  # noqa: SLF001
-                    callback_extra.set_options()
-                    if tqm_extra._callback_plugins:  # noqa: SLF001
-                        tqm_extra._callback_plugins[0] = callback_extra  # noqa: SLF001
-                tqm_extra.run(play_extra)
-            finally:
-                if tqm_extra:
-                    tqm_extra.cleanup()
-
-        # Raise exception if host(s) unreachable
+        Raises:
+            AnsibleConnectionFailure: When one or more hosts are unreachable.
+        """
         if callback.unreachable:
             msg = "Host unreachable in the inventory"
             raise AnsibleConnectionFailure(
@@ -289,18 +305,9 @@ class ModuleDispatcherV213(BaseModuleDispatcher):
                 dark=callback.unreachable,
                 contacted=callback.contacted,
             )
-        if self.options.get("extra_inventory_manager", None) and callback_extra.unreachable:
+        if callback_extra is not None and callback_extra.unreachable:
             raise AnsibleConnectionFailure(  # noqa: TRY003
                 "Host unreachable in the extra inventory",  # noqa: EM101
                 dark=callback_extra.unreachable,
                 contacted=callback_extra.contacted,
             )
-
-        # Success!
-        return AdHocResult(
-            contacted=(
-                {**callback.contacted, **callback_extra.contacted}
-                if self.options.get("extra_inventory_manager", None)
-                else callback.contacted
-            ),
-        )

--- a/src/pytest_ansible/module_dispatcher/v213.py
+++ b/src/pytest_ansible/module_dispatcher/v213.py
@@ -186,7 +186,7 @@ class ModuleDispatcherV213(BaseModuleDispatcher):
         """Validate that hosts matching the configured pattern exist.
 
         Raises:
-            ansible.errors.AnsibleError: When no hosts match after subsetting.
+            ansible.errors.AnsibleError: When no hosts match after applying subset.
         """
         hosts = self.options["inventory_manager"].list_hosts()
         extra_hosts = (

--- a/src/pytest_ansible/molecule.py
+++ b/src/pytest_ansible/molecule.py
@@ -31,36 +31,31 @@ logger = logging.getLogger(__name__)
 counter = 0
 
 
+def _populate_config_metadata(config) -> None:  # type: ignore[no-untyped-def]  # noqa: ANN001
+    """Populate pytest config metadata with molecule/ansible info and env vars."""
+    if not hasattr(config, "_metadata"):
+        return
+
+    interesting_env_vars = ("ANSIBLE", "MOLECULE", "DOCKER", "PODMAN", "VAGRANT", "VIRSH", "ZUUL")
+
+    for package in ["molecule"]:
+        config._metadata["Packages"][package] = version(package)  # noqa: SLF001
+
+    if "Tools" not in config._metadata:  # noqa: SLF001
+        config._metadata["Tools"] = {}  # noqa: SLF001
+    config._metadata["Tools"]["ansible"] = str(ansible_version())  # noqa: SLF001
+
+    env = ""
+    for key, value in sorted(os.environ.items()):
+        for var_name in interesting_env_vars:
+            if key.startswith(var_name):
+                env += f"{key}={value} "
+    config._metadata["env"] = env  # noqa: SLF001
+
+
 def molecule_pytest_configure(config):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201
     """Pytest hook for loading our specific configuration."""
-    interesting_env_vars = [
-        "ANSIBLE",
-        "MOLECULE",
-        "DOCKER",
-        "PODMAN",
-        "VAGRANT",
-        "VIRSH",
-        "ZUUL",
-    ]
-
-    # Add extra information that may be key for debugging failures
-    if hasattr(config, "_metadata"):
-        for package in ["molecule"]:
-            config._metadata["Packages"][package] = version(  # noqa: SLF001
-                package,
-            )
-
-        if "Tools" not in config._metadata:  # noqa: SLF001
-            config._metadata["Tools"] = {}  # noqa: SLF001
-        config._metadata["Tools"]["ansible"] = str(ansible_version())  # noqa: SLF001
-
-        # Adds interesting env vars
-        env = ""
-        for key, value in sorted(os.environ.items()):
-            for var_name in interesting_env_vars:
-                if key.startswith(var_name):
-                    env += f"{key}={value} "
-        config._metadata["env"] = env  # noqa: SLF001
+    _populate_config_metadata(config)
 
     # We hide DeprecationWarnings thrown by driver loading because these are
     # outside our control and worse: they are displayed even on projects that
@@ -199,30 +194,22 @@ class MoleculeItem(pytest.Item):
         if self.config.option.molecule_base_config:
             cmd.extend(("--base-config", self.config.option.molecule_base_config))
         if self.config.option.skip_no_git_change:
-            try:
-                with subprocess.Popen(  # noqa: S603
-                    [  # noqa: S607
-                        "git",
-                        "diff",
-                        self.config.option.skip_no_git_change,
-                        "--",
-                        "./",
-                    ],
-                    cwd=cwd,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
-                    universal_newlines=True,
-                ) as proc:
-                    proc.wait()
-                    if len(proc.stdout.readlines()) == 0:  # type: ignore[union-attr]
-                        pytest.skip("No change in role")
-            except subprocess.CalledProcessError as exc:
-                pytest.fail(
-                    "Error checking git diff. Error code was: "
-                    + str(exc.returncode)
-                    + "\nError output was: "
-                    + exc.output,
-                )
+            with subprocess.Popen(  # noqa: S603
+                [  # noqa: S607
+                    "git",
+                    "diff",
+                    self.config.option.skip_no_git_change,
+                    "--",
+                    "./",
+                ],
+                cwd=cwd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                universal_newlines=True,
+            ) as proc:
+                proc.wait()
+                if len(proc.stdout.readlines()) == 0:  # type: ignore[union-attr]
+                    pytest.skip("No change in role")
 
         cmd.extend(("test", "-s", scenario))
         # We append the additional options to molecule call, allowing user to
@@ -231,34 +218,26 @@ class MoleculeItem(pytest.Item):
         if opts:
             cmd.extend(shlex.split(opts))
 
-        if self.config.getoption("--molecule"):  # Check if --molecule option is enabled
-            try:
-                # Workaround for STDOUT/STDERR line ordering issue:
-                # https://github.com/pytest-dev/pytest/issues/5449
-                with subprocess.Popen(  # noqa: S603
-                    cmd,
-                    cwd=cwd,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
-                    universal_newlines=True,
-                ) as proc:
-                    for line in proc.stdout:  # type: ignore[union-attr]
-                        print(line, end="")  # noqa: T201
-                    proc.wait()
-                    if proc.returncode != 0:
-                        pytest.fail(
-                            f"Error code {proc.returncode} returned by: {' '.join(cmd)}",
-                            pytrace=False,
-                        )
-            except subprocess.CalledProcessError as exc:
-                pytest.fail(
-                    f"Exception {exc} returned by: {' '.join(cmd)}",
-                    pytrace=False,
-                )
+        if self.config.getoption("--molecule"):
+            # Workaround for STDOUT/STDERR line ordering issue:
+            # https://github.com/pytest-dev/pytest/issues/5449
+            with subprocess.Popen(  # noqa: S603
+                cmd,
+                cwd=cwd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                universal_newlines=True,
+            ) as proc:
+                for line in proc.stdout:  # type: ignore[union-attr]
+                    print(line, end="")  # noqa: T201
+                proc.wait()
+                if proc.returncode != 0:
+                    pytest.fail(
+                        f"Error code {proc.returncode} returned by: {' '.join(cmd)}",
+                        pytrace=False,
+                    )
         else:
-            pytest.skip(
-                "Molecule tests are disabled",
-            )  # Skip the test if --molecule option is not enabled
+            pytest.skip("Molecule tests are disabled")
 
     def reportinfo(self):  # type: ignore[no-untyped-def]  # noqa: ANN201
         """Return representation of test location when in verbose mode."""

--- a/src/pytest_ansible/plugin.py
+++ b/src/pytest_ansible/plugin.py
@@ -112,15 +112,11 @@ def _load_scenarios(config: pytest.Config) -> None:
 
 
 def pytest_load_initial_conftests(
-    early_config: pytest.Config,  # noqa: ARG001
-    parser: pytest.Parser,  # noqa: ARG001
     args: list[str],
 ) -> None:
     """Detect deprecated --connection usage and warn.
 
     Args:
-        early_config: pytest.Config (unused)
-        parser: pytest.Parser (unused)
         args: Combined list of CLI args and addopts values
     """
     for arg in args:
@@ -424,19 +420,22 @@ class PyTestAnsiblePlugin:
         """Return the version of ansible."""
         return f"ansible: {ansible.__version__}"
 
-    def pytest_collection_modifyitems(self, session, config, items):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201, ARG002
+    def pytest_collection_modifyitems(self, config, items):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN201
         """Validate --ansible-* parameters."""
-        uses_ansible_fixtures = False
+        if self._any_item_uses_ansible_fixtures(items):
+            self.assert_required_ansible_parameters(config)  # type: ignore[no-untyped-call]
+
+    @staticmethod
+    def _any_item_uses_ansible_fixtures(items) -> bool:  # type: ignore[no-untyped-def]  # noqa: ANN001
+        """Return True if any collected item requests one of OUR_FIXTURES."""
         for item in items:
             if not hasattr(item, "fixturenames"):
                 continue
 
             for fixture_name in item.fixturenames:
                 if fixture_name in OUR_FIXTURES:
-                    uses_ansible_fixtures = True
-                    break
+                    return True
 
-                # ignore any normal fixtures that have definitions to avoid miss activations
                 if (
                     hasattr(item, "_fixtureinfo")
                     and hasattr(item._fixtureinfo, "name2fixturedefs")  # noqa: SLF001
@@ -444,15 +443,12 @@ class PyTestAnsiblePlugin:
                 ):
                     continue
                 if fixture_name == "request":
-                    continue  # reserved name, from pytest
+                    continue
                 logger.error(
                     "Found %s fixture which seem to have no definition.",
                     fixture_name,
                 )
-
-        if uses_ansible_fixtures:
-            # assert required --ansible-* parameters were used
-            self.assert_required_ansible_parameters(config)  # type: ignore[no-untyped-call]
+        return False
 
     def _load_ansible_config(self, config):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN202
         """Load ansible configuration from command-line.

--- a/src/pytest_ansible/units.py
+++ b/src/pytest_ansible/units.py
@@ -65,6 +65,37 @@ def get_collection_name(start_path: Path) -> tuple[str | None, str | None]:
     return namespace, name
 
 
+def _resolve_collections_dir(
+    start_path: Path,
+    namespace: str,
+    name: str,
+) -> Path:
+    """Return the collections root directory, creating symlinks when needed.
+
+    :param start_path: The path where pytest was invoked.
+    :param namespace: The collection namespace.
+    :param name: The collection name.
+    :returns: Path to the directory containing ``ansible_collections/``.
+    """
+    collection_tree = ("collections", "ansible_collections", namespace, name)
+    if start_path.parts[-4:] == collection_tree:
+        logger.info("In collection tree")
+        return start_path.parents[2]
+
+    logger.info("Not in collection tree")
+    collections_dir = start_path / "collections"
+    name_dir = collections_dir / "ansible_collections" / namespace / name
+
+    if not name_dir.is_dir():
+        name_dir.mkdir(parents=True, exist_ok=True)
+        for entry in start_path.iterdir():
+            if entry.name == "collections":
+                continue
+            Path(name_dir / entry.name).symlink_to(entry)
+
+    return collections_dir
+
+
 def inject(start_path: Path) -> None:
     """Inject the collection path.
 
@@ -83,35 +114,14 @@ def inject(start_path: Path) -> None:
     logger.debug("Start path: %s", start_path)
     namespace, name = get_collection_name(start_path)
     if namespace is None or name is None:
-        # Tests may not being run from the root of the repo.
         return
 
-    # Determine if the start_path is in a collections tree
-    collection_tree = ("collections", "ansible_collections", namespace, name)
-    if start_path.parts[-4:] == collection_tree:
-        logger.info("In collection tree")
-        collections_dir = start_path.parents[2]
+    collections_dir = _resolve_collections_dir(start_path, namespace, name)
 
-    else:
-        logger.info("Not in collection tree")
-        collections_dir = start_path / "collections"
-        name_dir = collections_dir / "ansible_collections" / namespace / name
-
-        # If it's here, we will trust it was from this
-        if not name_dir.is_dir():
-            name_dir.mkdir(parents=True, exist_ok=True)
-
-            for entry in start_path.iterdir():
-                if entry.name == "collections":
-                    continue
-                Path(name_dir / entry.name).symlink_to(entry)
-
-    # Configuration option for additional collection paths
     additional_collections_paths: list[str] = [
         Path("~/.ansible/collections").expanduser().as_posix()
     ]
 
-    # Check if the environment variable is set for additional paths
     if "COLLECTIONS_PATH" in os.environ and "COLLECTIONS_PATHS" in os.environ:
         additional_collections_paths.extend(
             os.environ.get("COLLECTIONS_PATH", "").split(os.pathsep)
@@ -121,13 +131,10 @@ def inject(start_path: Path) -> None:
 
     acf_inject(paths=[str(collections_dir), *additional_collections_paths])
 
-    # Inject the path for the collection into sys.path
     sys.path.insert(0, str(collections_dir))
     logger.debug("sys.path updated: %s", sys.path)
 
-    # Set the environment variable as a courtesy for integration tests
     envvar_name = determine_envvar()
-    # Assuming additional_collections_paths is a list of PosixPath objects
     additional_collections_paths = [str(path) for path in additional_collections_paths]
     env_paths = os.pathsep.join([str(collections_dir), *additional_collections_paths])
     logger.info("Setting %s to %s", envvar_name, env_paths)

--- a/tests/integration/test_molecule.py
+++ b/tests/integration/test_molecule.py
@@ -9,10 +9,10 @@ import sys
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 
 if TYPE_CHECKING:
+    import pytest
+
     from _pytest.capture import CaptureFixture
 
     from pytest_ansible.molecule import MoleculeScenario
@@ -25,16 +25,13 @@ def test_molecule_collect(caplog: pytest.LogCaptureFixture) -> None:
         caplog: pytest caplog
     """
     with caplog.at_level(logging.WARNING):
-        try:
-            proc = subprocess.run(
-                "pytest --molecule --collect-only",  # noqa: S607
-                capture_output=True,
-                shell=True,
-                check=True,
-                text=True,
-            )
-        except subprocess.CalledProcessError as exc:
-            pytest.fail(exc.stderr)
+        proc = subprocess.run(
+            "pytest --molecule --collect-only",  # noqa: S607
+            capture_output=True,
+            shell=True,
+            check=True,
+            text=True,
+        )
 
         assert proc.returncode == 0
         assert "test1[default]" in proc.stdout
@@ -59,22 +56,18 @@ def test_molecule_disabled() -> None:
 
 def test_molecule_runtest() -> None:
     """Test running the molecule scenario via pytest."""
-    try:
-        proc = subprocess.run(
-            f"{sys.executable} -m pytest -v --molecule tests/fixtures/molecule/default/molecule.yml",  # noqa: E501
-            capture_output=True,
-            check=True,
-            env={"PATH": os.environ["PATH"]},
-            shell=True,
-            text=True,
-        )
-        assert proc.returncode == 0
-        assert "collected 1 item" in proc.stdout
-        assert "tests/fixtures/molecule/default/molecule.yml::test" in proc.stdout
-        assert "1 passed" in proc.stdout
-
-    except subprocess.CalledProcessError as exc:
-        pytest.fail(exc.stderr)
+    proc = subprocess.run(
+        f"{sys.executable} -m pytest -v --molecule tests/fixtures/molecule/default/molecule.yml",
+        capture_output=True,
+        check=True,
+        env={"PATH": os.environ["PATH"]},
+        shell=True,
+        text=True,
+    )
+    assert proc.returncode == 0
+    assert "collected 1 item" in proc.stdout
+    assert "tests/fixtures/molecule/default/molecule.yml::test" in proc.stdout
+    assert "1 passed" in proc.stdout
 
 
 def test_molecule_fixture(molecule_scenario: MoleculeScenario) -> None:

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -190,7 +190,7 @@ def test_deprecated_connection_warning() -> None:
     args: list[str] = ["--connection", "local"]
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        pytest_load_initial_conftests(early_config=None, parser=None, args=args)  # type: ignore[arg-type]
+        pytest_load_initial_conftests(args=args)
 
     assert len(caught) == 1
     assert issubclass(caught[0].category, DeprecationWarning)
@@ -204,7 +204,7 @@ def test_no_warning_without_connection_flag() -> None:
     args: list[str] = ["--ansible-connection", "local"]
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        pytest_load_initial_conftests(early_config=None, parser=None, args=args)  # type: ignore[arg-type]
+        pytest_load_initial_conftests(args=args)
 
     assert len(caught) == 0
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -129,7 +129,7 @@ def test_pytest_collection_modifyitems_with_marker():  # type: ignore[no-untyped
 
     # With the marker, ensure that assert_required_ansible_parameters is not called
     with mock.patch.object(plugin, "assert_required_ansible_parameters"):
-        plugin.pytest_collection_modifyitems(None, mock_config, items)  # type: ignore[no-untyped-call]
+        plugin.pytest_collection_modifyitems(mock_config, items)  # type: ignore[no-untyped-call]
 
 
 def test_pytest_collection_modifyitems_without_marker():  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
@@ -143,7 +143,7 @@ def test_pytest_collection_modifyitems_without_marker():  # type: ignore[no-unty
 
     # Without the marker, ensure that assert_required_ansible_parameters is called
     with mock.patch.object(plugin, "assert_required_ansible_parameters") as mock_assert:
-        plugin.pytest_collection_modifyitems(None, mock_config, items)  # type: ignore[no-untyped-call]
+        plugin.pytest_collection_modifyitems(mock_config, items)  # type: ignore[no-untyped-call]
         mock_assert.assert_called_once()
 
 
@@ -158,5 +158,5 @@ def test_pytest_collection_modifyitems_no_fixtures():  # type: ignore[no-untyped
 
     # With no fixtures, ensure that assert_required_ansible_parameters is not called
     with mock.patch.object(plugin, "assert_required_ansible_parameters") as mock_assert:
-        plugin.pytest_collection_modifyitems(None, mock_config, items)  # type: ignore[no-untyped-call]
+        plugin.pytest_collection_modifyitems(mock_config, items)  # type: ignore[no-untyped-call]
         mock_assert.assert_not_called()

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -9,7 +9,8 @@ import sys
 
 from typing import TYPE_CHECKING
 
-from pytest_ansible.units import inject, inject_only
+from pytest_ansible.molecule import _populate_config_metadata
+from pytest_ansible.units import _resolve_collections_dir, inject, inject_only
 
 
 if TYPE_CHECKING:
@@ -82,6 +83,43 @@ def test_inject_only(
         == re.search(r"_ACF installed: \['(.*?)'.*]", caplog.text).groups()[0]  # type: ignore[union-attr]
         == re.search(r"_ACF configured paths: \['(.*?)'.*]", caplog.text).groups()[0]  # type: ignore[union-attr]
     )
+
+
+def test_resolve_collections_dir_in_tree(tmp_path: Path) -> None:
+    """Test _resolve_collections_dir when already inside a collection tree.
+
+    :param tmp_path: The pytest tmp_path fixture
+    """
+    tree = tmp_path / "collections" / "ansible_collections" / "myns" / "myname"
+    tree.mkdir(parents=True)
+    result = _resolve_collections_dir(tree, "myns", "myname")
+    assert result == tmp_path / "collections"
+
+
+def test_populate_config_metadata_no_metadata() -> None:
+    """Test _populate_config_metadata returns early when config lacks _metadata."""
+
+    class FakeConfig:
+        """Config object without _metadata attribute."""
+
+    _populate_config_metadata(FakeConfig())
+
+
+def test_populate_config_metadata_with_metadata() -> None:
+    """Test _populate_config_metadata populates metadata correctly."""
+
+    class FakeConfig:
+        """Config object with a _metadata dict."""
+
+        _metadata: dict = {}  # type: ignore[type-arg]  # noqa: RUF012
+
+    config = FakeConfig()
+    config._metadata = {"Packages": {}}  # noqa: SLF001
+    _populate_config_metadata(config)
+    assert "molecule" in config._metadata["Packages"]  # noqa: SLF001
+    assert "Tools" in config._metadata  # noqa: SLF001
+    assert "ansible" in config._metadata["Tools"]  # noqa: SLF001
+    assert "env" in config._metadata  # noqa: SLF001
 
 
 def test_for_params():  # type: ignore[no-untyped-def]  # noqa: ANN201

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -90,9 +90,9 @@ def test_resolve_collections_dir_in_tree(tmp_path: Path) -> None:
 
     :param tmp_path: The pytest tmp_path fixture
     """
-    tree = tmp_path / "collections" / "ansible_collections" / "myns" / "myname"
+    tree = tmp_path / "collections" / "ansible_collections" / "testns" / "testname"
     tree.mkdir(parents=True)
-    result = _resolve_collections_dir(tree, "myns", "myname")
+    result = _resolve_collections_dir(tree, "testns", "testname")
     assert result == tmp_path / "collections"
 
 
@@ -111,15 +111,15 @@ def test_populate_config_metadata_with_metadata() -> None:
     class FakeConfig:
         """Config object with a _metadata dict."""
 
-        _metadata: dict = {}  # type: ignore[type-arg]  # noqa: RUF012
+        def __init__(self) -> None:
+            self._metadata: dict = {"Packages": {}}  # type: ignore[type-arg]
 
     config = FakeConfig()
-    config._metadata = {"Packages": {}}  # noqa: SLF001
     _populate_config_metadata(config)
-    assert "molecule" in config._metadata["Packages"]  # noqa: SLF001
-    assert "Tools" in config._metadata  # noqa: SLF001
-    assert "ansible" in config._metadata["Tools"]  # noqa: SLF001
-    assert "env" in config._metadata  # noqa: SLF001
+    assert "molecule" in config._metadata["Packages"]
+    assert "Tools" in config._metadata
+    assert "ansible" in config._metadata["Tools"]
+    assert "env" in config._metadata
 
 
 def test_for_params():  # type: ignore[no-untyped-def]  # noqa: ANN201

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -90,9 +90,9 @@ def test_resolve_collections_dir_in_tree(tmp_path: Path) -> None:
 
     :param tmp_path: The pytest tmp_path fixture
     """
-    tree = tmp_path / "collections" / "ansible_collections" / "testns" / "testname"
+    tree = tmp_path / "collections" / "ansible_collections" / "namespace" / "name"
     tree.mkdir(parents=True)
-    result = _resolve_collections_dir(tree, "testns", "testname")
+    result = _resolve_collections_dir(tree, "namespace", "name")
     assert result == tmp_path / "collections"
 
 


### PR DESCRIPTION
S3776 cognitive complexity reductions:
- v213.py _run (43->~12): extract _assert_hosts_exist, _configure_adhoc_cli, _build_tqm_kwargs, _build_play_ds, _raise_on_unreachable, _execute_play
- molecule.py molecule_pytest_configure (19->~8): extract _populate_config_metadata
- units.py inject (17->~8): extract _resolve_collections_dir
- plugin.py pytest_collection_modifyitems (16->~2): extract _any_item_uses_ansible_fixtures

S1172 unused parameter removals:
- plugin.py: remove early_config, parser from pytest_load_initial_conftests
- plugin.py: remove session from pytest_collection_modifyitems

S8714 unnecessary try/except in test code:
- molecule.py runtest(): remove 2 try/except blocks wrapping subprocess calls
- tests/integration/test_molecule.py: remove 2 try/except blocks