### PR TITLE
test: boost new-code coverage past 90% for SonarCloud quality gate

### DIFF
--- a/.config/pydoclint-baseline.txt
+++ b/.config/pydoclint-baseline.txt
@@ -322,4 +322,6 @@ tests/unit/test_unit.py
     DOC103: Function `test_resolve_collections_dir_in_tree`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [tmp_path: Path].
     DOC101: Function `test_resolve_collections_dir_existing_dir`: Docstring contains fewer arguments than in function signature.
     DOC103: Function `test_resolve_collections_dir_existing_dir`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [tmp_path: Path].
+    DOC101: Function `test_resolve_collections_dir_creates_symlinks`: Docstring contains fewer arguments than in function signature.
+    DOC103: Function `test_resolve_collections_dir_creates_symlinks`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [tmp_path: Path].
 --------------------

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -354,3 +354,31 @@ def test_warn_or_fail_pre_v219():  # type: ignore[no-untyped-def]  # noqa: ANN20
     assert len(caught) == 1
     assert issubclass(caught[0].category, DeprecationWarning)
     assert "ansible_host" in str(caught[0].message)
+
+
+def test_pytest_load_initial_conftests_connection_equals():  # type: ignore[no-untyped-def]  # noqa: ANN201
+    """The --connection=value form should also trigger a deprecation warning."""
+    import warnings
+
+    from pytest_ansible.plugin import pytest_load_initial_conftests
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        pytest_load_initial_conftests(args=["--connection=local"])
+
+    assert len(caught) == 1
+    assert issubclass(caught[0].category, DeprecationWarning)
+    assert "--ansible-connection" in str(caught[0].message)
+
+
+def test_pytest_load_initial_conftests_no_connection():  # type: ignore[no-untyped-def]  # noqa: ANN201
+    """No warning emitted when --connection is absent."""
+    import warnings
+
+    from pytest_ansible.plugin import pytest_load_initial_conftests
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        pytest_load_initial_conftests(args=["--verbose", "--ansible-connection=local"])
+
+    assert len(caught) == 0

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -305,7 +305,7 @@ def test_execute_play_v219_empty_callback_plugins() -> None:
         patch("pytest_ansible.module_dispatcher.v213.has_ansible_v219", True),  # noqa: FBT003
     ):
         play = MagicMock()
-        callback = MagicMock(spec=ResultAccumulator)
+        callback = MagicMock()
         _execute_play(play, {}, callback)
 
     mock_tqm_instance.load_callbacks.assert_called_once()
@@ -326,7 +326,7 @@ def test_execute_play_v219_with_callback_plugins() -> None:
         patch("pytest_ansible.module_dispatcher.v213.has_ansible_v219", True),  # noqa: FBT003
     ):
         play = MagicMock()
-        callback = MagicMock(spec=ResultAccumulator)
+        callback = MagicMock()
         _execute_play(play, {}, callback)
 
     assert mock_tqm_instance._callback_plugins[0] is callback

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -191,8 +191,8 @@ def test_resolve_collections_dir_creates_symlinks(tmp_path: Path) -> None:
     (tmp_path / "module_a.py").write_text("# module a")
     (tmp_path / "README.md").write_text("# readme")
 
-    result = _resolve_collections_dir(tmp_path, "myns", "mycol")
-    name_dir = tmp_path / "collections" / "ansible_collections" / "myns" / "mycol"
+    result = _resolve_collections_dir(tmp_path, "ns", "col")
+    name_dir = tmp_path / "collections" / "ansible_collections" / "ns" / "col"
     assert result == tmp_path / "collections"
     assert name_dir.is_dir()
     assert (name_dir / "module_a.py").is_symlink()
@@ -255,7 +255,7 @@ def test_result_accumulator_on_failed() -> None:
     result._host.get_name.return_value = "host1"
     result._result = {"rc": 1, "stderr": "error"}
 
-    acc.v2_runner_on_failed(result)
+    acc.v2_runner_on_failed(result)  # type: ignore[no-untyped-call]
     assert "host1" in acc.contacted
     assert acc.contacted["host1"]["failed"] is True
     assert acc.contacted["host1"]["rc"] == 1
@@ -267,7 +267,7 @@ def test_result_accumulator_results_property() -> None:
     result = MagicMock()
     result._host.get_name.return_value = "h1"
     result._result = {"changed": True}
-    acc.v2_runner_on_ok(result)
+    acc.v2_runner_on_ok(result)  # type: ignore[no-untyped-call]
 
     assert acc.results == {"contacted": {"h1": {"changed": True}}, "unreachable": {}}
 
@@ -305,7 +305,7 @@ def test_execute_play_v219_empty_callback_plugins() -> None:
         patch("pytest_ansible.module_dispatcher.v213.has_ansible_v219", True),  # noqa: FBT003
     ):
         play = MagicMock()
-        callback = ResultAccumulator()
+        callback = MagicMock(spec=ResultAccumulator)
         _execute_play(play, {}, callback)
 
     mock_tqm_instance.load_callbacks.assert_called_once()
@@ -326,7 +326,7 @@ def test_execute_play_v219_with_callback_plugins() -> None:
         patch("pytest_ansible.module_dispatcher.v213.has_ansible_v219", True),  # noqa: FBT003
     ):
         play = MagicMock()
-        callback = ResultAccumulator()
+        callback = MagicMock(spec=ResultAccumulator)
         _execute_play(play, {}, callback)
 
     assert mock_tqm_instance._callback_plugins[0] is callback
@@ -339,7 +339,7 @@ def test_result_accumulator_on_unreachable() -> None:
     result._host.get_name.return_value = "unreachable_host"
     result._result = {"msg": "No route to host"}
 
-    acc.v2_runner_on_unreachable(result)
+    acc.v2_runner_on_unreachable(result)  # type: ignore[no-untyped-call]
     assert "unreachable_host" in acc.unreachable
     assert acc.unreachable["unreachable_host"]["msg"] == "No route to host"
 

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -8,7 +8,13 @@ import subprocess  # noqa: S404
 import sys
 
 from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
 
+from pytest_ansible.module_dispatcher.v213 import (
+    ModuleDispatcherV213,
+    ResultAccumulator,
+    _execute_play,
+)
 from pytest_ansible.molecule import _populate_config_metadata
 from pytest_ansible.units import _resolve_collections_dir, inject, inject_only
 
@@ -177,6 +183,23 @@ def test_resolve_collections_dir_existing_dir(tmp_path: Path) -> None:
     assert result == collections_dir
 
 
+def test_resolve_collections_dir_creates_symlinks(tmp_path: Path) -> None:
+    """Test _resolve_collections_dir creates symlinks when name_dir does not exist.
+
+    :param tmp_path: The pytest tmp_path fixture
+    """
+    (tmp_path / "module_a.py").write_text("# module a")
+    (tmp_path / "README.md").write_text("# readme")
+
+    result = _resolve_collections_dir(tmp_path, "myns", "mycol")
+    name_dir = tmp_path / "collections" / "ansible_collections" / "myns" / "mycol"
+    assert result == tmp_path / "collections"
+    assert name_dir.is_dir()
+    assert (name_dir / "module_a.py").is_symlink()
+    assert (name_dir / "README.md").is_symlink()
+    assert not (name_dir / "collections").exists()
+
+
 def test_for_params():  # type: ignore[no-untyped-def]  # noqa: ANN201
     """Test for params."""
     proc = subprocess.run(
@@ -186,3 +209,177 @@ def test_for_params():  # type: ignore[no-untyped-def]  # noqa: ANN201
         check=False,
     )
     assert "--ansible-unit-inject-only" in proc.stdout.decode()
+
+
+def test_raise_on_unreachable_extra_callback() -> None:
+    """Test _raise_on_unreachable raises for unreachable hosts in extra callback."""
+    import pytest
+
+    from pytest_ansible.errors import AnsibleConnectionFailure
+
+    callback = ResultAccumulator()
+    callback_extra = ResultAccumulator()
+    callback_extra.unreachable = {"extra_host": {"msg": "unreachable"}}
+    callback_extra.contacted = {}
+
+    with pytest.raises(AnsibleConnectionFailure, match="extra inventory"):
+        ModuleDispatcherV213._raise_on_unreachable(callback, callback_extra)
+
+
+def test_raise_on_unreachable_primary_callback() -> None:
+    """Test _raise_on_unreachable raises for unreachable hosts in primary callback."""
+    import pytest
+
+    from pytest_ansible.errors import AnsibleConnectionFailure
+
+    callback = ResultAccumulator()
+    callback.unreachable = {"host1": {"msg": "unreachable"}}
+    callback.contacted = {}
+
+    with pytest.raises(AnsibleConnectionFailure, match="Host unreachable"):
+        ModuleDispatcherV213._raise_on_unreachable(callback, None)
+
+
+def test_raise_on_unreachable_no_unreachable() -> None:
+    """Test _raise_on_unreachable does not raise when all hosts reachable."""
+    callback = ResultAccumulator()
+    callback_extra = ResultAccumulator()
+
+    ModuleDispatcherV213._raise_on_unreachable(callback, callback_extra)
+
+
+def test_result_accumulator_on_failed() -> None:
+    """Test ResultAccumulator.v2_runner_on_failed records failures."""
+    acc = ResultAccumulator()
+    result = MagicMock()
+    result._host.get_name.return_value = "host1"
+    result._result = {"rc": 1, "stderr": "error"}
+
+    acc.v2_runner_on_failed(result)
+    assert "host1" in acc.contacted
+    assert acc.contacted["host1"]["failed"] is True
+    assert acc.contacted["host1"]["rc"] == 1
+
+
+def test_result_accumulator_results_property() -> None:
+    """Test ResultAccumulator.results property returns expected dict."""
+    acc = ResultAccumulator()
+    result = MagicMock()
+    result._host.get_name.return_value = "h1"
+    result._result = {"changed": True}
+    acc.v2_runner_on_ok(result)
+
+    assert acc.results == {"contacted": {"h1": {"changed": True}}, "unreachable": {}}
+
+
+def test_execute_play_non_v219() -> None:
+    """Test _execute_play when has_ansible_v219 is False."""
+    mock_tqm_instance = MagicMock()
+
+    with (
+        patch(
+            "pytest_ansible.module_dispatcher.v213.TaskQueueManager",
+            return_value=mock_tqm_instance,
+        ),
+        patch("pytest_ansible.module_dispatcher.v213.has_ansible_v219", False),  # noqa: FBT003
+    ):
+        play = MagicMock()
+        callback = ResultAccumulator()
+        _execute_play(play, {}, callback)
+
+    mock_tqm_instance.run.assert_called_once_with(play)
+    mock_tqm_instance.cleanup.assert_called_once()
+    mock_tqm_instance.load_callbacks.assert_not_called()
+
+
+def test_execute_play_v219_empty_callback_plugins() -> None:
+    """Test _execute_play with v219 when _callback_plugins is empty."""
+    mock_tqm_instance = MagicMock()
+    mock_tqm_instance._callback_plugins = []
+
+    with (
+        patch(
+            "pytest_ansible.module_dispatcher.v213.TaskQueueManager",
+            return_value=mock_tqm_instance,
+        ),
+        patch("pytest_ansible.module_dispatcher.v213.has_ansible_v219", True),  # noqa: FBT003
+    ):
+        play = MagicMock()
+        callback = ResultAccumulator()
+        _execute_play(play, {}, callback)
+
+    mock_tqm_instance.load_callbacks.assert_called_once()
+    mock_tqm_instance.run.assert_called_once_with(play)
+
+
+def test_execute_play_v219_with_callback_plugins() -> None:
+    """Test _execute_play with v219 replaces the first callback plugin."""
+    mock_tqm_instance = MagicMock()
+    original_plugin = MagicMock()
+    mock_tqm_instance._callback_plugins = [original_plugin]
+
+    with (
+        patch(
+            "pytest_ansible.module_dispatcher.v213.TaskQueueManager",
+            return_value=mock_tqm_instance,
+        ),
+        patch("pytest_ansible.module_dispatcher.v213.has_ansible_v219", True),  # noqa: FBT003
+    ):
+        play = MagicMock()
+        callback = ResultAccumulator()
+        _execute_play(play, {}, callback)
+
+    assert mock_tqm_instance._callback_plugins[0] is callback
+
+
+def test_result_accumulator_on_unreachable() -> None:
+    """Test ResultAccumulator.v2_runner_on_unreachable records unreachable hosts."""
+    acc = ResultAccumulator()
+    result = MagicMock()
+    result._host.get_name.return_value = "unreachable_host"
+    result._result = {"msg": "No route to host"}
+
+    acc.v2_runner_on_unreachable(result)
+    assert "unreachable_host" in acc.unreachable
+    assert acc.unreachable["unreachable_host"]["msg"] == "No route to host"
+
+
+def test_build_tqm_kwargs_non_v219() -> None:
+    """Test _build_tqm_kwargs includes stdout_callback when not v219."""
+    dispatcher = MagicMock(spec=ModuleDispatcherV213)
+    dispatcher.options = {
+        "inventory_manager": MagicMock(),
+        "variable_manager": MagicMock(),
+        "loader": MagicMock(),
+    }
+    callback = ResultAccumulator()
+
+    with patch("pytest_ansible.module_dispatcher.v213.has_ansible_v219", False):  # noqa: FBT003
+        result = ModuleDispatcherV213._build_tqm_kwargs(dispatcher, callback)
+
+    assert result["stdout_callback"] is callback
+    assert "stdout_callback_name" not in result
+
+
+def test_build_tqm_kwargs_extra() -> None:
+    """Test _build_tqm_kwargs with extra=True uses extra_ prefixed options."""
+    dispatcher = MagicMock(spec=ModuleDispatcherV213)
+    extra_inv = MagicMock()
+    extra_vm = MagicMock()
+    extra_loader = MagicMock()
+    dispatcher.options = {
+        "inventory_manager": MagicMock(),
+        "variable_manager": MagicMock(),
+        "loader": MagicMock(),
+        "extra_inventory_manager": extra_inv,
+        "extra_variable_manager": extra_vm,
+        "extra_loader": extra_loader,
+    }
+    callback = ResultAccumulator()
+
+    with patch("pytest_ansible.module_dispatcher.v213.has_ansible_v219", True):  # noqa: FBT003
+        result = ModuleDispatcherV213._build_tqm_kwargs(dispatcher, callback, extra=True)
+
+    assert result["inventory"] is extra_inv
+    assert result["variable_manager"] is extra_vm
+    assert result["loader"] is extra_loader


### PR DESCRIPTION
## Summary

- Add unit tests covering previously uncovered branches in new code to push SonarCloud coverage past the 90% quality gate threshold.

**Coverage improvements target:**
- `module_dispatcher/v213.py`: `_execute_play` (non-v219, v219 with empty/populated callback_plugins), `ResultAccumulator` callbacks + `results`, `_raise_on_unreachable` (primary/extra), `_build_tqm_kwargs` (non-v219, extra=True)
- `units.py`: `_resolve_collections_dir` symlink creation with `collections/` skip
- `plugin.py`: `pytest_load_initial_conftests` with `--connection=value` form

Follows up on #599 which was merged before the coverage commit was pushed.

## Test plan

- [x] All 313 tests pass locally
- [x] ruff check + format clean
- [x] pydoclint baseline updated
- [x] SonarCloud new-code coverage >= 90%
