### PR TITLE
chore: deprecate molecule scenario integration via pytest

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -33,8 +33,6 @@ getplugin
 inlinehilite
 junitxml
 lineinfile
-linenums
-magiclink
 makeconftest
 makepyfile
 metafunc
@@ -46,13 +44,11 @@ pluginmanager
 posargs
 prek
 pydoclint
-pymdownx
 pytester
 pytestmark
 pytrace
 reportinfo
 runpytest
-superfences
 testinfra
 testpaths
 tombi

--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -14,12 +14,10 @@ addini
 addinivalue
 addoption
 addopts
-autorefs
 autouse
 capfd
 caplog
 conftests
-facelessuser
 fixturedefs
 fixtureinfo
 fixturenames
@@ -30,13 +28,11 @@ funcargs
 getfixturevalue
 getgroup
 getplugin
-inlinehilite
 junitxml
 lineinfile
 makeconftest
 makepyfile
 metafunc
-mkdocstrings
 modifyitems
 pandoc
 parseoutcomes

--- a/README.md
+++ b/README.md
@@ -132,64 +132,38 @@ E   ModuleNotFoundError: No module named 'ansible_collections'
 HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file modules
 ```
 
-## Molecule Scenario Integration
+## Molecule Scenario Integration (deprecated)
 
-This functionality assists in running Molecule `scenarios` using `pytest`. It
-enables pytest discovery of all `molecule.yml` files inside the codebase and
-runs them as pytest tests. It allows you to include Molecule scenarios as part
-of your pytest test suite, allowing you to thoroughly test your Ansible roles
-and playbooks across different scenarios and environments.
+> **Deprecated:** Running Molecule scenarios via pytest-ansible will be removed
+> in a future release.
 
-## Running molecule scenarios using pytest
+Prefer the Molecule CLI (and tox-ansible for collections):
 
-Molecule scenarios can be tested using 2 different methods if molecule is
-installed.
-
-**Recommended:**
-
-Add a `test_integration.py` file to the `tests/integration` directory of the
-ansible collection:
-
-```
-"""Tests for molecule scenarios."""
-from __future__ import absolute_import, division, print_function
-
-from pytest_ansible.molecule import MoleculeScenario
-
-
-def test_integration(molecule_scenario: MoleculeScenario) -> None:
-    """Run molecule for each scenario.
-
-    :param molecule_scenario: The molecule scenario object
-    """
-    proc = molecule_scenario.test()
-    assert proc.returncode == 0
+```bash
+molecule test --all
+# With shared_state collections, use molecule's own concurrency:
+molecule test --all --workers 4
 ```
 
-The `molecule_scenario` fixture provides parameterized molecule scenarios
-discovered in the collection's `extensions/molecule` directory, as well as other
-directories within the collection.
+### Why this is deprecated
 
-`molecule test -s <scenario>` will be run for each scenario and a completed
-subprocess returned from the `test()` call.
+pytest-ansible runs each scenario as a separate `molecule test -s <scenario>`
+subprocess. That only works for **standalone** scenarios. It does **not**
+support Molecule `shared_state` (create once in the default scenario, run
+component scenarios, destroy once) or `--workers`. Those require Molecule's
+native multi-scenario orchestration.
 
-**Legacy:**
+### Migration
 
-Run molecule with the `--molecule` command line parameter to inject each
-molecule directory found in the current working directory. Each scenario will be
-injected as an external test in the the tests available for pytest. Due to the
-nature of this approach, the molecule scenarios are not represented as python
-tests and may not show in the IDE's pytest test tree.
+| Old (pytest-ansible) | New |
+| --- | --- |
+| `molecule_scenario` fixture + glue test file | `molecule test --all` |
+| `pytest --molecule` | `molecule test --all` |
+| Collection CI via pytest integration env | tox-ansible molecule test type |
 
-To run Molecule scenarios using pytest, follow these steps:
-
-1. Install the `pytest-ansible` plugin using pip:
-
-```
-pip install pytest-ansible
-```
-
-2. Execute pytest to run Molecule scenarios: `pytest`
+The `--molecule*` CLI options, `molecule_scenario` fixture, and
+`pytest_ansible.molecule.MoleculeScenario` remain available temporarily but
+emit a `DeprecationWarning`.
 
 ## Ansible Integration for Pytest Tests
 
@@ -229,9 +203,9 @@ pytest \
     [--ask-become-pass] \
     [--limit <limit>] \
     [--ansible-unit-inject-only] \
-    [--molecule] \
-    [--molecule-unavailable-driver] \
-    [--skip-no-git-change] \
+    [--molecule] \                       # deprecated
+    [--molecule-unavailable-driver] \    # deprecated
+    [--skip-no-git-change] \             # deprecated
     [--check]
 ```
 

--- a/README.md
+++ b/README.md
@@ -203,11 +203,14 @@ pytest \
     [--ask-become-pass] \
     [--limit <limit>] \
     [--ansible-unit-inject-only] \
-    [--molecule] \                       # deprecated
-    [--molecule-unavailable-driver] \    # deprecated
-    [--skip-no-git-change] \             # deprecated
+    [--molecule] \
+    [--molecule-unavailable-driver] \
+    [--skip-no-git-change] \
     [--check]
 ```
+
+`--molecule`, `--molecule-unavailable-driver`, and `--skip-no-git-change` are
+deprecated; prefer `molecule test --all`.
 
 ### Inventory
 

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -18,6 +18,7 @@ ignorePaths:
   - \.*
   - cspell.config.yaml
   - uv.lock
+  - mkdocs.yml
 
   - "*.egg-info"
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -86,44 +86,37 @@ E   ModuleNotFoundError: No module named 'ansible_collections'
 HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file modules
 ```
 
-## Molecule Scenario Integration
+## Molecule Scenario Integration (deprecated)
 
-This functionality assists in running Molecule `scenarios` using `pytest`. It
-enables pytest discovery of all `molecule.yml` files inside the codebase and
-runs them as pytest tests. It allows you to include Molecule scenarios as part
-of your pytest test suite, allowing you to thoroughly test your Ansible roles
-and playbooks across different scenarios and environments.
+!!! warning
 
-## Running molecule scenarios using pytest
+    Running Molecule scenarios via pytest-ansible is **deprecated** and will be
+    removed in a future release.
 
-Molecule scenarios can be tested using 2 different methods if molecule is
-installed.
+Prefer the Molecule CLI (and tox-ansible for collections):
 
-**Recommended:**
-
-Add a `test_integration.py` file to the `tests/integration` directory of the
-ansible collection:
-
-```python
-"""Tests for molecule scenarios."""
-
-from __future__ import absolute_import, division, print_function
-
-from pytest_ansible.molecule import MoleculeScenario
-
-
-def test_integration(molecule_scenario: MoleculeScenario) -> None:
-    """Run molecule for each scenario.
-
-    :param molecule_scenario: The molecule scenario object
-    """
-    proc = molecule_scenario.test()
-    assert proc.returncode == 0
+```bash
+molecule test --all
+# With shared_state collections, use molecule's own concurrency:
+molecule test --all --workers 4
 ```
 
-The `molecule_scenario` fixture provides parameterized molecule scenarios
-discovered in the collection's `extensions/molecule` directory, as well as other
-directories within the collection.
+### Why this is deprecated
 
-`molecule test -s <scenario>` will be run for each scenario and a completed
-subprocess returned from the `test()` call.
+pytest-ansible runs each scenario as a separate `molecule test -s <scenario>`
+subprocess. That only works for **standalone** scenarios. It does **not**
+support Molecule `shared_state` (create once in the default scenario, run
+component scenarios, destroy once) or `--workers`. Those require Molecule's
+native multi-scenario orchestration.
+
+### Migration
+
+| Old (pytest-ansible) | New |
+| --- | --- |
+| `molecule_scenario` fixture + glue test file | `molecule test --all` |
+| `pytest --molecule` | `molecule test --all` |
+| Collection CI via pytest integration env | tox-ansible molecule test type |
+
+The `--molecule*` CLI options, `molecule_scenario` fixture, and
+`pytest_ansible.molecule.MoleculeScenario` remain available temporarily but
+emit a `DeprecationWarning`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,20 +5,19 @@
 The `pytest-ansible` plugin is designed to provide seamless integration between
 `pytest` and `Ansible`, allowing you to efficiently run and test Ansible-related
 tasks and scenarios within your pytest test suite. This plugin enhances the
-testing workflow by offering three distinct pieces of functionality:
+testing workflow by offering these pieces of functionality:
 
 1. **Unit Testing for Ansible Collections**: This feature aids in running unit
    tests for `Ansible collections` using `pytest`. It allows you to validate the
    behavior of your Ansible `modules` and `roles` in isolation, ensuring that
    each component functions as expected.
 
-2. **Molecule Scenario Integration**: The plugin assists in running Molecule
-   `scenarios` using `pytest`. This integration streamlines the testing of
-   Ansible roles and playbooks across different environments, making it easier
-   to identify and fix issues across diverse setups.
-
-3. **Ansible Integration for Pytest Tests**: With this functionality, you can
+2. **Ansible Integration for Pytest Tests**: With this functionality, you can
    seamlessly use `Ansible` from within your `pytest` tests. This opens up
    possibilities to interact with Ansible components and perform tasks like
    provisioning resources, testing configurations, and more, all while
    leveraging the power and flexibility of pytest.
+
+Molecule scenario integration via pytest-ansible is **deprecated**. Run scenarios
+with the Molecule CLI (`molecule test --all`) or tox-ansible instead. See
+[Getting started](getting_started.md#molecule-scenario-integration-deprecated).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -378,7 +378,8 @@ filterwarnings = [
   "ignore:Host management is deprecated and will be removed in a future release:DeprecationWarning",
   "ignore:ansible_host fixture is deprecated and will be removed in a future release.:DeprecationWarning",
   "ignore:ansible_group fixture is deprecated and will be removed in a future release.:DeprecationWarning",
-  "ignore:pytest-ansible no longer supports the '--connection' option:DeprecationWarning"
+  "ignore:pytest-ansible no longer supports the '--connection' option:DeprecationWarning",
+  "ignore:Running Molecule scenarios via pytest-ansible is deprecated:DeprecationWarning"
 ]
 junit_family = "xunit2"
 markers = ["old", "unit", "requires_ansible_v2"]

--- a/src/pytest_ansible/molecule.py
+++ b/src/pytest_ansible/molecule.py
@@ -26,6 +26,29 @@ from ansible_compat.config import ansible_version
 molecule_spec = importlib.util.find_spec("molecule")
 HAS_MOLECULE = molecule_spec is not None
 
+MOLECULE_DEPRECATION = (
+    "Running Molecule scenarios via pytest-ansible is deprecated and will be "
+    "removed in a future release. Use the Molecule CLI instead "
+    "(`molecule test --all`, optionally with `--workers` when using "
+    "shared_state). For collections, prefer tox-ansible's molecule test type. "
+    "See the pytest-ansible documentation for migration details."
+)
+
+_molecule_deprecation_warned = False
+
+
+def warn_molecule_deprecated(*, stacklevel: int = 2) -> None:
+    """Emit a one-time DeprecationWarning for molecule-via-pytest usage.
+
+    Args:
+        stacklevel: Warning stacklevel passed to warnings.warn.
+    """
+    global _molecule_deprecation_warned  # noqa: PLW0603
+    if _molecule_deprecation_warned:
+        return
+    _molecule_deprecation_warned = True
+    warnings.warn(MOLECULE_DEPRECATION, DeprecationWarning, stacklevel=stacklevel)
+
 
 logger = logging.getLogger(__name__)
 counter = 0
@@ -272,6 +295,7 @@ class MoleculeScenario:
         Returns:
             The completed process
         """
+        warn_molecule_deprecated()
         args = [sys.executable, "-m", "molecule", "test", "-s", self.name]
 
         # We append the additional options to molecule call, allowing user to

--- a/src/pytest_ansible/plugin.py
+++ b/src/pytest_ansible/plugin.py
@@ -282,19 +282,25 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "--molecule_unavailable_driver",
         action="store",
         default=None,
-        help="DEPRECATED: What marker to add to molecule scenarios when driver is ",
+        help=("DEPRECATED: What marker to add to molecule scenarios when driver is unavailable."),
     )
     group.addoption(
         "--molecule_base_config",
         action="store",
         default=None,
-        help="DEPRECATED: Path to the molecule base config file. The value of this option is ",
+        help=(
+            "DEPRECATED: Path to the molecule base config file. The value of this "
+            "option is passed to molecule."
+        ),
     )
     group.addoption(
         "--skip_no_git_change",
         action="store",
         default=None,
-        help="DEPRECATED: Commit to use as a reference for this test. If the role wasn't",
+        help=(
+            "DEPRECATED: Commit to use as a reference for this test. If the role "
+            "wasn't changed, the scenario is skipped."
+        ),
     )
     # Add github marker to --help
     parser.addini("ansible", "Ansible integration", "args")

--- a/src/pytest_ansible/plugin.py
+++ b/src/pytest_ansible/plugin.py
@@ -36,7 +36,12 @@ from pytest_ansible.fixtures import (
 from pytest_ansible.has_version import has_ansible_v219
 from pytest_ansible.host_manager.utils import get_host_manager
 
-from .molecule import HAS_MOLECULE, MoleculeFile, MoleculeScenario
+from .molecule import (
+    HAS_MOLECULE,
+    MoleculeFile,
+    MoleculeScenario,
+    warn_molecule_deprecated,
+)
 from .units import inject, inject_only
 
 
@@ -114,11 +119,20 @@ def _load_scenarios(config: pytest.Config) -> None:
 def pytest_load_initial_conftests(
     args: list[str],
 ) -> None:
-    """Detect deprecated --connection usage and warn.
+    """Detect deprecated --connection / --molecule usage and warn.
 
     Args:
         args: Combined list of CLI args and addopts values
     """
+    molecule_cli_options = (
+        "--molecule",
+        "--molecule_unavailable_driver",
+        "--molecule-unavailable-driver",
+        "--molecule_base_config",
+        "--molecule-base-config",
+        "--skip_no_git_change",
+        "--skip-no-git-change",
+    )
     for arg in args:
         if arg == "--connection" or arg.startswith("--connection="):
             warnings.warn(
@@ -129,6 +143,12 @@ def pytest_load_initial_conftests(
                 DeprecationWarning,
                 stacklevel=1,
             )
+            break
+
+    for arg in args:
+        option = arg.split("=", maxsplit=1)[0]
+        if option in molecule_cli_options:
+            warn_molecule_deprecated(stacklevel=1)
             break
 
 
@@ -253,25 +273,28 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "--molecule",
         action="store_true",
         default=False,
-        help="Enable support for running discovered molecule scenarios from pytest.",
+        help=(
+            "DEPRECATED: Enable support for running discovered molecule scenarios "
+            "from pytest. Use `molecule test --all` instead."
+        ),
     )
     group.addoption(
         "--molecule_unavailable_driver",
         action="store",
         default=None,
-        help="What marker to add to molecule scenarios when driver is ",
+        help="DEPRECATED: What marker to add to molecule scenarios when driver is ",
     )
     group.addoption(
         "--molecule_base_config",
         action="store",
         default=None,
-        help="Path to the molecule base config file. The value of this option is ",
+        help="DEPRECATED: Path to the molecule base config file. The value of this option is ",
     )
     group.addoption(
         "--skip_no_git_change",
         action="store",
         default=None,
-        help="Commit to use as a reference for this test. If the role wasn't",
+        help="DEPRECATED: Commit to use as a reference for this test. If the role wasn't",
     )
     # Add github marker to --help
     parser.addini("ansible", "Ansible integration", "args")
@@ -326,6 +349,7 @@ def pytest_collect_file(
         return None
     if not parent.config.option.molecule:
         return None
+    warn_molecule_deprecated()
     if not HAS_MOLECULE:  # pragma: no cover
         pytest.exit(
             f"molecule not installed or found, unable to collect test {file_path}",
@@ -399,6 +423,7 @@ def pytest_generate_tests(metafunc):  # type: ignore[no-untyped-def]  # noqa: AN
         metafunc.parametrize("ansible_group", iter(hosts[g] for g in extra_groups))
 
     if "molecule_scenario" in metafunc.fixturenames:
+        warn_molecule_deprecated()
         if not HAS_MOLECULE:
             pytest.exit("molecule not installed or found.")
 

--- a/tests/unit/test_molecule_deprecation.py
+++ b/tests/unit/test_molecule_deprecation.py
@@ -1,0 +1,53 @@
+"""Tests for molecule-via-pytest deprecation warnings."""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from pytest_ansible import molecule as molecule_mod
+from pytest_ansible.molecule import MOLECULE_DEPRECATION, warn_molecule_deprecated
+from pytest_ansible.plugin import pytest_load_initial_conftests
+
+
+@pytest.fixture(autouse=True)
+def _reset_molecule_deprecation_flag() -> None:
+    """Ensure each test can observe a fresh deprecation warning."""
+    molecule_mod._molecule_deprecation_warned = False
+
+
+def test_warn_molecule_deprecated_emits_once() -> None:
+    """warn_molecule_deprecated should emit a single DeprecationWarning."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        warn_molecule_deprecated()
+        warn_molecule_deprecated()
+
+    assert len(caught) == 1
+    assert issubclass(caught[0].category, DeprecationWarning)
+    assert MOLECULE_DEPRECATION in str(caught[0].message)
+
+
+@pytest.mark.parametrize(
+    "args",
+    (
+        ["--molecule"],
+        ["--molecule_base_config=/tmp/base.yml"],
+        ["--molecule-unavailable-driver=skip"],
+        ["--skip-no-git-change=HEAD~1"],
+    ),
+)
+def test_molecule_cli_options_warn(args: list[str]) -> None:
+    """Deprecated molecule CLI options should warn during conftest load.
+
+    Args:
+        args: CLI args that should trigger the molecule deprecation warning.
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        pytest_load_initial_conftests(args)
+
+    molecule_warnings = [w for w in caught if MOLECULE_DEPRECATION in str(w.message)]
+    assert len(molecule_warnings) == 1
+    assert issubclass(molecule_warnings[0].category, DeprecationWarning)


### PR DESCRIPTION
## Summary
- Deprecate running Molecule scenarios through pytest-ansible (`--molecule*`, `molecule_scenario` fixture, `MoleculeScenario`).
- Document migration to `molecule test --all` / tox-ansible — per-scenario pytest orchestration cannot support `shared_state` or `--workers`.

## Changes
- Emit a one-time `DeprecationWarning` when molecule-via-pytest APIs are used
- Mark molecule CLI options as DEPRECATED in `--help` (with complete help text)
- Rewrite README and docs molecule sections with rationale + migration table
- Add unit tests for the deprecation warning paths
- Suppress the warning in the project's pytest `filterwarnings` so existing suite runs stay quiet
- Ignore `mkdocs.yml` in cspell (mkdocs-only tokens) so dictionary cleanup does not fail lint

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e py` passes (full suite on initial push; deprecation unit tests on follow-up)
- [x] Docs updated (README, `docs/getting_started.md`, `docs/index.md`)
- [x] CodeRabbit feedback addressed (c6be695)

Related: ansible/handbook#1520

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deprecation**
  - Running Molecule scenarios through pytest-ansible is deprecated.
  - Deprecated Molecule-related options, fixtures, and integrations remain temporarily available and now emit deprecation warnings consistently.

- **Documentation**
  - Updated getting started and index content with deprecation notices, migration guidance, and limitations (including `shared_state` and worker concurrency).
  - Clarified preferred approaches via Molecule CLI (`molecule test --all`) or tox-ansible, and marked related CLI flags as deprecated.

- **Bug Fixes**
  - Deprecation warnings are triggered reliably in legacy flows.

- **Tests**
  - Added unit tests to verify warnings emit once and for supported legacy options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->