### PR TITLE
test: raise unit coverage to ~98% for SonarCloud

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -19,10 +19,12 @@ capfd
 caplog
 conftest
 conftests
+delenv
 fixturedefs
 fixtureinfo
 fixturenames
 fqcn
+fromlist
 fspath
 fstring
 funcargs
@@ -36,6 +38,7 @@ makeconftest
 makepyfile
 metafunc
 modifyitems
+nodeid
 pandoc
 parseoutcomes
 pluginmanager

--- a/src/pytest_ansible/plugin.py
+++ b/src/pytest_ansible/plugin.py
@@ -424,9 +424,9 @@ def pytest_generate_tests(metafunc):  # type: ignore[no-untyped-def]  # noqa: AN
             raise pytest.UsageError(exception)  # noqa: B904
         groups = hosts.options["inventory_manager"].list_groups()
         extra_groups = hosts.get_extra_inventory_groups()
-        # Return the group name as a string
-        metafunc.parametrize("ansible_group", iter(hosts[g] for g in groups))
-        metafunc.parametrize("ansible_group", iter(hosts[g] for g in extra_groups))
+        # Return the group name as a string (once — pytest rejects duplicate fixture names)
+        all_groups = [*groups, *extra_groups]
+        metafunc.parametrize("ansible_group", iter(hosts[g] for g in all_groups))
 
     if "molecule_scenario" in metafunc.fixturenames:
         warn_molecule_deprecated()

--- a/src/pytest_ansible/plugin.py
+++ b/src/pytest_ansible/plugin.py
@@ -424,8 +424,8 @@ def pytest_generate_tests(metafunc):  # type: ignore[no-untyped-def]  # noqa: AN
             raise pytest.UsageError(exception)  # noqa: B904
         groups = hosts.options["inventory_manager"].list_groups()
         extra_groups = hosts.get_extra_inventory_groups()
-        # Return the group name as a string (once — pytest rejects duplicate fixture names)
-        all_groups = [*groups, *extra_groups]
+        # Parametrize once (pytest rejects duplicate fixture names) with stable dedupe
+        all_groups = list(dict.fromkeys([*groups, *extra_groups]))
         metafunc.parametrize("ansible_group", iter(hosts[g] for g in all_groups))
 
     if "molecule_scenario" in metafunc.fixturenames:

--- a/src/pytest_ansible/plugin.py
+++ b/src/pytest_ansible/plugin.py
@@ -424,7 +424,7 @@ def pytest_generate_tests(metafunc):  # type: ignore[no-untyped-def]  # noqa: AN
             raise pytest.UsageError(exception)  # noqa: B904
         groups = hosts.options["inventory_manager"].list_groups()
         extra_groups = hosts.get_extra_inventory_groups()
-        # Parametrize once (pytest rejects duplicate fixture names) with stable dedupe
+        # Parametrize once (pytest rejects duplicate fixture names); drop overlaps
         all_groups = list(dict.fromkeys([*groups, *extra_groups]))
         metafunc.parametrize("ansible_group", iter(hosts[g] for g in all_groups))
 

--- a/tests/test_adhoc_result.py
+++ b/tests/test_adhoc_result.py
@@ -174,4 +174,4 @@ def test_connection_failure_extra_inventory_v2():  # type: ignore[no-untyped-def
 def test_adhoc_result_keys_method() -> None:
     """AdHocResult.keys should return contacted host keys."""
     result = AdHocResult(contacted={"h1": {"changed": False}, "h2": {"changed": True}})
-    assert set(result.keys()) == {"h1", "h2"}
+    assert set(result.keys()) == {"h1", "h2"}  # type: ignore[no-untyped-call]

--- a/tests/test_adhoc_result.py
+++ b/tests/test_adhoc_result.py
@@ -6,7 +6,7 @@ from types import GeneratorType
 
 import pytest
 
-from pytest_ansible.results import ModuleResult
+from pytest_ansible.results import AdHocResult, ModuleResult
 
 from .conftest import ALL_EXTRA_HOSTS, ALL_HOSTS
 
@@ -169,3 +169,9 @@ def test_connection_failure_extra_inventory_v2():  # type: ignore[no-untyped-def
         "Failed to connect to the host via ssh"
         in exc_info.value.dark["unknown.example.extra.com"]["msg"]
     )
+
+
+def test_adhoc_result_keys_method() -> None:
+    """AdHocResult.keys should return contacted host keys."""
+    result = AdHocResult(contacted={"h1": {"changed": False}, "h2": {"changed": True}})
+    assert set(result.keys()) == {"h1", "h2"}

--- a/tests/test_host_manager.py
+++ b/tests/test_host_manager.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
+import ansible.errors
 import pytest
+
+from pytest_ansible.host_manager.base import BaseHostManager
+from pytest_ansible.host_manager.utils import get_host_manager
 
 from .conftest import (
     ALL_EXTRA_HOSTS,
@@ -183,3 +189,72 @@ def test_defaults(request):  # type: ignore[no-untyped-def]  # noqa: ANN001, ANN
 
     assert "connection" in hosts.options
     assert hosts.options["connection"] == DEFAULT_TRANSPORT
+
+
+def test_get_host_manager_unsupported() -> None:
+    """get_host_manager raises when ansible < 2.13."""
+    with (
+        patch("pytest_ansible.host_manager.utils.has_ansible_v213", new=False),
+        pytest.raises(RuntimeError, match="Unable to find any supported HostManager"),
+    ):
+        get_host_manager(inventory="localhost,")
+
+
+def test_base_host_manager_default_dispatcher() -> None:
+    """_default_dispatcher is a no-op."""
+    manager = BaseHostManager.__new__(BaseHostManager)
+    manager.options = {"inventory": "localhost,"}
+    assert manager._default_dispatcher() is None
+
+
+def test_base_host_manager_missing_required_kwargs() -> None:
+    """check_required_kwargs raises TypeError when inventory is missing."""
+    manager = BaseHostManager.__new__(BaseHostManager)
+    manager.options = {}
+    with pytest.raises(TypeError, match="Missing required keyword argument"):
+        manager.check_required_kwargs()
+
+
+def test_base_host_manager_has_matching_inventory_ansible_error() -> None:
+    """has_matching_inventory returns False on AnsibleError."""
+    manager = BaseHostManager.__new__(BaseHostManager)
+    inv = MagicMock()
+    inv.list_hosts.side_effect = ansible.errors.AnsibleError("bad pattern")
+    manager.options = {"inventory_manager": inv}
+    assert manager.has_matching_inventory("broken[") is False
+
+
+def test_base_host_manager_getitem_from_dict() -> None:
+    """__getitem__ returns values already present on the instance dict."""
+    manager = BaseHostManager.__new__(BaseHostManager)
+    manager.options = {"inventory": "localhost,"}
+    manager.custom_attr = "value"  # type: ignore[attr-defined]
+    assert manager["custom_attr"] == "value"
+
+
+def test_base_host_manager_iter() -> None:
+    """__iter__ yields dispatcher entries for matched hosts."""
+    manager = BaseHostManager.__new__(BaseHostManager)
+    host = MagicMock()
+    host.name = "localhost"
+    inv = MagicMock()
+    inv.list_hosts.return_value = [host]
+    dispatcher = MagicMock(return_value="disp")
+    manager.options = {
+        "inventory": "localhost,",
+        "inventory_manager": inv,
+        "host_pattern": "all",
+    }
+    manager._dispatcher = dispatcher
+    manager.get_extra_inventory_hosts = MagicMock(return_value=[])  # type: ignore[method-assign]
+    manager.has_matching_inventory = MagicMock(return_value=True)  # type: ignore[method-assign]
+
+    result = list(iter(manager))
+    assert result == ["disp"]
+
+
+def test_base_host_manager_initialize_inventory_not_implemented() -> None:
+    """initialize_inventory must be implemented by subclasses."""
+    manager = BaseHostManager.__new__(BaseHostManager)
+    with pytest.raises(NotImplementedError, match="Must be implemented by sub-class"):
+        manager.initialize_inventory()

--- a/tests/test_host_manager.py
+++ b/tests/test_host_manager.py
@@ -204,7 +204,7 @@ def test_base_host_manager_default_dispatcher() -> None:
     """_default_dispatcher is a no-op."""
     manager = BaseHostManager.__new__(BaseHostManager)
     manager.options = {"inventory": "localhost,"}
-    assert manager._default_dispatcher() is None
+    assert manager._default_dispatcher() is None  # type: ignore[no-untyped-call]
 
 
 def test_base_host_manager_missing_required_kwargs() -> None:
@@ -212,7 +212,7 @@ def test_base_host_manager_missing_required_kwargs() -> None:
     manager = BaseHostManager.__new__(BaseHostManager)
     manager.options = {}
     with pytest.raises(TypeError, match="Missing required keyword argument"):
-        manager.check_required_kwargs()
+        manager.check_required_kwargs()  # type: ignore[no-untyped-call]
 
 
 def test_base_host_manager_has_matching_inventory_ansible_error() -> None:
@@ -221,7 +221,7 @@ def test_base_host_manager_has_matching_inventory_ansible_error() -> None:
     inv = MagicMock()
     inv.list_hosts.side_effect = ansible.errors.AnsibleError("bad pattern")
     manager.options = {"inventory_manager": inv}
-    assert manager.has_matching_inventory("broken[") is False
+    assert manager.has_matching_inventory("broken[") is False  # type: ignore[no-untyped-call]
 
 
 def test_base_host_manager_getitem_from_dict() -> None:
@@ -257,4 +257,4 @@ def test_base_host_manager_initialize_inventory_not_implemented() -> None:
     """initialize_inventory must be implemented by subclasses."""
     manager = BaseHostManager.__new__(BaseHostManager)
     with pytest.raises(NotImplementedError, match="Must be implemented by sub-class"):
-        manager.initialize_inventory()
+        manager.initialize_inventory()  # type: ignore[no-untyped-call]

--- a/tests/test_module_dispatcher.py
+++ b/tests/test_module_dispatcher.py
@@ -17,8 +17,6 @@ from .conftest import NEGATIVE_HOST_PATTERNS, POSITIVE_HOST_PATTERNS
 
 def test_type_error() -> None:
     """Verify that BaseModuleDispatcher cannot be instantiated."""
-    from pytest_ansible.module_dispatcher import BaseModuleDispatcher
-
     with pytest.raises(TypeError, match=r"^Can't instantiate.*$"):
         BaseModuleDispatcher(inventory="localhost,")  # type: ignore[abstract] #pylint: disable=abstract-class-instantiated
 
@@ -87,21 +85,32 @@ def test_ansible_module_error(hosts):  # type: ignore[no-untyped-def]  # noqa: A
 class _ConcreteDispatcher(BaseModuleDispatcher):
     """Minimal concrete dispatcher for testing base-class branches."""
 
-    def has_module(self, name: str) -> str:
+    def has_module(self, name: str) -> str:  # pylint: disable=useless-parent-delegation
         """Delegate to base implementation for coverage.
+
+        Args:
+            name: Module name passed through to the base method
 
         Returns:
             Result of the base has_module implementation.
         """
         return super().has_module(name)
 
-    def _run(self, *args, **kwargs):  # type: ignore[no-untyped-def]  # noqa: ANN002, ANN003, ANN202
+    def _run(  # pylint: disable=useless-parent-delegation
+        self,
+        *args: object,
+        **kwargs: object,
+    ) -> object:
         """Delegate to base implementation for coverage.
+
+        Args:
+            *args: Positional args forwarded to the base method
+            **kwargs: Keyword args forwarded to the base method
 
         Returns:
             Result of the base _run implementation.
         """
-        return super()._run(*args, **kwargs)
+        return super()._run(*args, **kwargs)  # type: ignore[no-untyped-call]
 
 
 def test_base_dispatcher_missing_required_kwargs() -> None:
@@ -140,7 +149,7 @@ def test_v213_reload_without_custom_loader_support() -> None:
         if fromlist and "init_plugin_loader" in fromlist:
             msg = "init_plugin_loader unavailable"
             raise ImportError(msg)
-        return real_import(name, globals, locals, fromlist, level)
+        return real_import(name, globals, locals, fromlist, level)  # type: ignore[arg-type]
 
     try:
         if original is not None:
@@ -243,7 +252,7 @@ def test_module_dispatcher_run_without_custom_loader() -> None:
         patch.object(dispatcher, "_raise_on_unreachable"),
     ):
         mock_play.return_value.load.return_value = MagicMock()
-        dispatcher._run()
+        dispatcher._run()  # type: ignore[no-untyped-call]
 
     mock_init.assert_not_called()
 
@@ -277,7 +286,7 @@ def test_module_dispatcher_run_with_module_args() -> None:
         patch.object(dispatcher, "_raise_on_unreachable"),
     ):
         mock_play.return_value.load.return_value = MagicMock()
-        result = dispatcher._run("arg1", "arg2")
+        result = dispatcher._run("arg1", "arg2")  # type: ignore[no-untyped-call]
 
     assert "arg1" in mock_ds.call_args[0][0]["_raw_params"]
     assert result.contacted == {}
@@ -301,7 +310,11 @@ def test_module_dispatcher_assert_hosts_exist_no_match() -> None:
 def test_module_dispatcher_configure_adhoc_cli_verbosity_and_flags(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """_configure_adhoc_cli handles verbosity and boolean option flags."""
+    """_configure_adhoc_cli handles verbosity and boolean option flags.
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture
+    """
     dispatcher = ModuleDispatcherV213.__new__(ModuleDispatcherV213)
     dispatcher.options = {
         "host_pattern": "localhost",

--- a/tests/test_module_dispatcher.py
+++ b/tests/test_module_dispatcher.py
@@ -167,6 +167,8 @@ def test_v213_reload_without_custom_loader_support() -> None:
 
 def test_execute_play_tqm_init_failure() -> None:
     """_execute_play cleanup is skipped when TaskQueueManager construction fails."""
+    play = MagicMock()
+    variable_manager = MagicMock()
     with (
         patch(
             "pytest_ansible.module_dispatcher.v213.TaskQueueManager",
@@ -174,22 +176,23 @@ def test_execute_play_tqm_init_failure() -> None:
         ),
         pytest.raises(RuntimeError, match="tqm init failed"),
     ):
-        _execute_play(MagicMock(), {}, MagicMock())
+        _execute_play(play, {}, variable_manager)
 
 
 def test_module_dispatcher_v213_requires_ansible() -> None:
     """ModuleDispatcherV213 raises ImportError when ansible < 2.13."""
+    kwargs = {
+        "inventory": "localhost,",
+        "inventory_manager": MagicMock(),
+        "variable_manager": MagicMock(),
+        "host_pattern": "all",
+        "loader": MagicMock(),
+    }
     with (
         patch("pytest_ansible.module_dispatcher.v213.has_ansible_v213", new=False),
         pytest.raises(ImportError, match=r"Only supported with ansible-2\.13"),
     ):
-        ModuleDispatcherV213(
-            inventory="localhost,",
-            inventory_manager=MagicMock(),
-            variable_manager=MagicMock(),
-            host_pattern="all",
-            loader=MagicMock(),
-        )
+        ModuleDispatcherV213(**kwargs)
 
 
 def test_module_dispatcher_has_module_string_path() -> None:

--- a/tests/test_module_dispatcher.py
+++ b/tests/test_module_dispatcher.py
@@ -2,7 +2,15 @@
 
 from __future__ import annotations
 
+import sys
+
+from unittest.mock import MagicMock, patch
+
+import ansible.errors
 import pytest
+
+from pytest_ansible.module_dispatcher import BaseModuleDispatcher
+from pytest_ansible.module_dispatcher.v213 import ModuleDispatcherV213, _execute_play
 
 from .conftest import NEGATIVE_HOST_PATTERNS, POSITIVE_HOST_PATTERNS
 
@@ -74,3 +82,239 @@ def test_ansible_module_error(hosts):  # type: ignore[no-untyped-def]  # noqa: A
         str(exc_info.value)
         == f"The module {'a_module_that_most_certainly_does_not_exist'} was not found in configured module paths."  # noqa: E501
     )
+
+
+class _ConcreteDispatcher(BaseModuleDispatcher):
+    """Minimal concrete dispatcher for testing base-class branches."""
+
+    def has_module(self, name: str) -> str:
+        """Delegate to base implementation for coverage.
+
+        Returns:
+            Result of the base has_module implementation.
+        """
+        return super().has_module(name)
+
+    def _run(self, *args, **kwargs):  # type: ignore[no-untyped-def]  # noqa: ANN002, ANN003, ANN202
+        """Delegate to base implementation for coverage.
+
+        Returns:
+            Result of the base _run implementation.
+        """
+        return super()._run(*args, **kwargs)
+
+
+def test_base_dispatcher_missing_required_kwargs() -> None:
+    """BaseModuleDispatcher raises TypeError when required kwargs missing."""
+    with pytest.raises(TypeError, match="Missing required keyword argument"):
+        _ConcreteDispatcher()
+
+
+def test_base_dispatcher_abstract_method_bodies() -> None:
+    """Cover abstract method bodies via super() calls from a concrete subclass."""
+    dispatcher = _ConcreteDispatcher(inventory="localhost,")
+    assert not dispatcher.has_module("ping")
+    with pytest.raises(RuntimeError, match="Must be implemented by a sub-class"):
+        dispatcher._run()
+
+
+def test_v213_reload_without_custom_loader_support() -> None:
+    """Cover ImportError path that disables HAS_CUSTOM_LOADER_SUPPORT."""
+    import builtins
+    import importlib
+
+    import ansible.plugins.loader as real_loader
+
+    import pytest_ansible.module_dispatcher.v213 as v213_mod
+
+    original = getattr(real_loader, "init_plugin_loader", None)
+    real_import = builtins.__import__
+
+    def fake_import(
+        name: str,
+        globals: object = None,  # noqa: A002
+        locals: object = None,  # noqa: A002
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
+        if fromlist and "init_plugin_loader" in fromlist:
+            msg = "init_plugin_loader unavailable"
+            raise ImportError(msg)
+        return real_import(name, globals, locals, fromlist, level)
+
+    try:
+        if original is not None:
+            del real_loader.init_plugin_loader
+        with patch("builtins.__import__", side_effect=fake_import):
+            reloaded = importlib.reload(v213_mod)
+        assert reloaded.HAS_CUSTOM_LOADER_SUPPORT is False
+    finally:
+        if original is not None:
+            real_loader.init_plugin_loader = original
+        importlib.reload(v213_mod)
+
+    assert v213_mod.HAS_CUSTOM_LOADER_SUPPORT is True
+
+
+def test_execute_play_tqm_init_failure() -> None:
+    """_execute_play cleanup is skipped when TaskQueueManager construction fails."""
+    with (
+        patch(
+            "pytest_ansible.module_dispatcher.v213.TaskQueueManager",
+            side_effect=RuntimeError("tqm init failed"),
+        ),
+        pytest.raises(RuntimeError, match="tqm init failed"),
+    ):
+        _execute_play(MagicMock(), {}, MagicMock())
+
+
+def test_module_dispatcher_v213_requires_ansible() -> None:
+    """ModuleDispatcherV213 raises ImportError when ansible < 2.13."""
+    with (
+        patch("pytest_ansible.module_dispatcher.v213.has_ansible_v213", new=False),
+        pytest.raises(ImportError, match=r"Only supported with ansible-2\.13"),
+    ):
+        ModuleDispatcherV213(
+            inventory="localhost,",
+            inventory_manager=MagicMock(),
+            variable_manager=MagicMock(),
+            host_pattern="all",
+            loader=MagicMock(),
+        )
+
+
+def test_module_dispatcher_has_module_string_path() -> None:
+    """has_module accepts a single string module_path."""
+    dispatcher = ModuleDispatcherV213.__new__(ModuleDispatcherV213)
+    dispatcher.options = {
+        "inventory": "localhost,",
+        "inventory_manager": MagicMock(),
+        "variable_manager": MagicMock(),
+        "host_pattern": "all",
+        "loader": MagicMock(),
+        "module_path": "/tmp/modules",  # noqa: S108
+    }
+    with patch("pytest_ansible.module_dispatcher.v213.module_loader") as mock_loader:
+        found = MagicMock()
+        found.resolved = True
+        found.resolved_fqcn = "ansible.builtin.ping"
+        mock_loader.find_plugin_with_context.return_value = found
+        assert dispatcher.has_module("ping") == "ansible.builtin.ping"
+        mock_loader.add_directory.assert_called_with("/tmp/modules")  # noqa: S108
+
+
+def test_module_dispatcher_has_module_not_found() -> None:
+    """has_module returns empty string on ModuleNotFoundError."""
+    dispatcher = ModuleDispatcherV213.__new__(ModuleDispatcherV213)
+    dispatcher.options = {
+        "inventory": "localhost,",
+        "inventory_manager": MagicMock(),
+        "variable_manager": MagicMock(),
+        "host_pattern": "all",
+        "loader": MagicMock(),
+    }
+    with patch("pytest_ansible.module_dispatcher.v213.module_loader") as mock_loader:
+        mock_loader.find_plugin_with_context.side_effect = ModuleNotFoundError("missing")
+        assert not dispatcher.has_module("nope")
+
+
+def test_module_dispatcher_run_without_custom_loader() -> None:
+    """_run skips init_plugin_loader when custom loader support is absent."""
+    dispatcher = ModuleDispatcherV213.__new__(ModuleDispatcherV213)
+    dispatcher.options = {
+        "inventory": "localhost,",
+        "inventory_manager": MagicMock(),
+        "variable_manager": MagicMock(),
+        "host_pattern": "localhost",
+        "loader": MagicMock(),
+        "module_name": "ping",
+    }
+    dispatcher.options["inventory_manager"].list_hosts.return_value = [MagicMock()]
+
+    with (
+        patch.object(dispatcher, "_assert_hosts_exist"),
+        patch.object(dispatcher, "_configure_adhoc_cli"),
+        patch.object(dispatcher, "_build_tqm_kwargs", return_value={}),
+        patch.object(dispatcher, "_build_play_ds", return_value={}),
+        patch("pytest_ansible.module_dispatcher.v213.Play") as mock_play,
+        patch("pytest_ansible.module_dispatcher.v213._execute_play"),
+        patch("pytest_ansible.module_dispatcher.v213.HAS_CUSTOM_LOADER_SUPPORT", new=False),
+        patch("pytest_ansible.module_dispatcher.v213.init_plugin_loader") as mock_init,
+        patch.object(dispatcher, "_raise_on_unreachable"),
+    ):
+        mock_play.return_value.load.return_value = MagicMock()
+        dispatcher._run()
+
+    mock_init.assert_not_called()
+
+
+def test_module_dispatcher_run_with_module_args() -> None:
+    """_run merges positional module args into complex_args."""
+    dispatcher = ModuleDispatcherV213.__new__(ModuleDispatcherV213)
+    dispatcher.options = {
+        "inventory": "localhost,",
+        "inventory_manager": MagicMock(),
+        "variable_manager": MagicMock(),
+        "host_pattern": "localhost",
+        "loader": MagicMock(),
+        "module_name": "ping",
+    }
+    dispatcher.options["inventory_manager"].list_hosts.return_value = [MagicMock()]
+
+    with (
+        patch.object(dispatcher, "_assert_hosts_exist"),
+        patch.object(dispatcher, "_configure_adhoc_cli"),
+        patch.object(dispatcher, "_build_tqm_kwargs", return_value={}),
+        patch.object(
+            dispatcher,
+            "_build_play_ds",
+            side_effect=lambda complex_args: {"args": complex_args},
+        ) as mock_ds,
+        patch("pytest_ansible.module_dispatcher.v213.Play") as mock_play,
+        patch("pytest_ansible.module_dispatcher.v213._execute_play"),
+        patch("pytest_ansible.module_dispatcher.v213.HAS_CUSTOM_LOADER_SUPPORT", new=True),
+        patch("pytest_ansible.module_dispatcher.v213.init_plugin_loader"),
+        patch.object(dispatcher, "_raise_on_unreachable"),
+    ):
+        mock_play.return_value.load.return_value = MagicMock()
+        result = dispatcher._run("arg1", "arg2")
+
+    assert "arg1" in mock_ds.call_args[0][0]["_raw_params"]
+    assert result.contacted == {}
+
+
+def test_module_dispatcher_assert_hosts_exist_no_match() -> None:
+    """_assert_hosts_exist raises when subset matches no hosts."""
+    dispatcher = ModuleDispatcherV213.__new__(ModuleDispatcherV213)
+    inv = MagicMock()
+    host = MagicMock()
+    inv.list_hosts.side_effect = [[host], []]
+    dispatcher.options = {
+        "inventory_manager": inv,
+        "host_pattern": "nomatch",
+        "subset": "nomatch",
+    }
+    with pytest.raises(ansible.errors.AnsibleError, match="does not match any hosts"):
+        dispatcher._assert_hosts_exist()
+
+
+def test_module_dispatcher_configure_adhoc_cli_verbosity_and_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_configure_adhoc_cli handles verbosity and boolean option flags."""
+    dispatcher = ModuleDispatcherV213.__new__(ModuleDispatcherV213)
+    dispatcher.options = {
+        "host_pattern": "localhost",
+        "connection": "local",
+        "become": True,
+        "user": None,
+    }
+    monkeypatch.setattr(sys, "argv", ["pytest", "-vv", "tests"])
+
+    with patch("pytest_ansible.module_dispatcher.v213.AdHocCLI") as mock_cli:
+        mock_cli.return_value.parse = MagicMock()
+        dispatcher._configure_adhoc_cli()
+        args = mock_cli.call_args[0][0]
+        assert "-vv" in args
+        assert "--become" in args
+        assert "--connection=local" in args

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -591,8 +591,8 @@ def test_pytest_generate_tests_ansible_group_mocked() -> None:
 
     hosts = MagicMock()
     hosts.options = {"inventory_manager": MagicMock()}
-    hosts.options["inventory_manager"].list_groups.return_value = ["group1"]
-    hosts.get_extra_inventory_groups.return_value = ["extra_group"]
+    hosts.options["inventory_manager"].list_groups.return_value = ["group1", "shared"]
+    hosts.get_extra_inventory_groups.return_value = ["extra_group", "shared"]
     hosts.__getitem__ = MagicMock(side_effect=lambda key: key)
 
     plugin = MagicMock()
@@ -608,7 +608,7 @@ def test_pytest_generate_tests_ansible_group_mocked() -> None:
     metafunc.parametrize.assert_called_once()
     args, _kwargs = metafunc.parametrize.call_args
     assert args[0] == "ansible_group"
-    assert list(args[1]) == ["group1", "extra_group"]
+    assert list(args[1]) == ["group1", "shared", "extra_group"]
 
 
 def test_pytest_generate_tests_ansible_host_success() -> None:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -229,8 +229,6 @@ def test_any_item_uses_ansible_fixtures_logs_undefined(
     Args:
         caplog: pytest log capture fixture
     """
-    import logging
-
     with caplog.at_level(logging.ERROR, logger="pytest_ansible.plugin"):
         result = PyTestAnsiblePlugin._any_item_uses_ansible_fixtures(
             [MockItem(fixturenames=["unknown_fixture"])],
@@ -275,8 +273,6 @@ def test_any_item_uses_ansible_fixtures_no_name2fixturedefs():  # type: ignore[n
 
 def test_pytest_collect_file_no_molecule_option():  # type: ignore[no-untyped-def]  # noqa: ANN201
     """Return None when config.option has no molecule attribute."""
-    from pytest_ansible.plugin import pytest_collect_file
-
     parent = MagicMock()
     del parent.config.option.molecule
 
@@ -286,8 +282,6 @@ def test_pytest_collect_file_no_molecule_option():  # type: ignore[no-untyped-de
 
 def test_pytest_collect_file_molecule_disabled():  # type: ignore[no-untyped-def]  # noqa: ANN201
     """Return None when --molecule is not enabled."""
-    from pytest_ansible.plugin import pytest_collect_file
-
     parent = MagicMock()
     parent.config.option.molecule = False
 
@@ -301,8 +295,6 @@ def test_pytest_collect_file_symlink(tmp_path):  # type: ignore[no-untyped-def] 
     Args:
         tmp_path: pytest tmp_path fixture
     """
-    from pytest_ansible.plugin import pytest_collect_file
-
     real_file = tmp_path / "real_molecule.yml"
     real_file.write_text("---\n")
     symlink = tmp_path / "molecule.yml"
@@ -321,8 +313,6 @@ def test_pytest_collect_file_non_molecule_yml(tmp_path):  # type: ignore[no-unty
     Args:
         tmp_path: pytest tmp_path fixture
     """
-    from pytest_ansible.plugin import pytest_collect_file
-
     other_file = tmp_path / "playbook.yml"
     other_file.write_text("---\n")
 
@@ -335,8 +325,6 @@ def test_pytest_collect_file_non_molecule_yml(tmp_path):  # type: ignore[no-unty
 
 def test_warn_or_fail_on_v219():  # type: ignore[no-untyped-def]  # noqa: ANN201
     """On Ansible 2.19+, warn_or_fail should call pytest.exit."""
-    from unittest.mock import patch
-
     from pytest_ansible.plugin import warn_or_fail
 
     with (
@@ -350,8 +338,6 @@ def test_warn_or_fail_on_v219():  # type: ignore[no-untyped-def]  # noqa: ANN201
 def test_warn_or_fail_pre_v219():  # type: ignore[no-untyped-def]  # noqa: ANN201
     """Before Ansible 2.19, warn_or_fail should emit a DeprecationWarning."""
     import warnings
-
-    from unittest.mock import patch
 
     from pytest_ansible.plugin import warn_or_fail
 
@@ -411,7 +397,12 @@ def test_pytest_configure_verbose_and_inject(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """pytest_configure sets verbosity and injects collection path."""
+    """pytest_configure sets verbosity and injects collection path.
+
+    Args:
+        tmp_path: Temporary directory for a fake collection root
+        monkeypatch: pytest monkeypatch fixture
+    """
     (tmp_path / "galaxy.yml").write_text(
         "namespace: ns\nname: col\n",
         encoding="utf-8",
@@ -462,7 +453,11 @@ def test_pytest_configure_verbose_display_fallback() -> None:
 
 
 def test_pytest_collect_file_molecule_yml(tmp_path: Path) -> None:
-    """pytest_collect_file returns MoleculeFile for molecule.yml."""
+    """pytest_collect_file returns MoleculeFile for molecule.yml.
+
+    Args:
+        tmp_path: Temporary directory containing molecule.yml
+    """
     mol = tmp_path / "molecule.yml"
     mol.write_text("---\n", encoding="utf-8")
     parent = MagicMock()
@@ -473,10 +468,11 @@ def test_pytest_collect_file_molecule_yml(tmp_path: Path) -> None:
         patch("pytest_ansible.plugin.warn_molecule_deprecated"),
         patch("pytest_ansible.plugin.MoleculeFile") as mock_file,
     ):
-        mock_file.from_parent.return_value = "molecule-file"
+        molecule_node = MagicMock(name="molecule-file")
+        mock_file.from_parent.return_value = molecule_node
         result = pytest_collect_file(file_path=mol, parent=parent)
 
-    assert result == "molecule-file"
+    assert result is molecule_node
     mock_file.from_parent.assert_called_once()
 
 
@@ -490,7 +486,7 @@ def test_pytest_generate_tests_molecule_scenario_without_molecule() -> None:
         patch("pytest_ansible.plugin.warn_molecule_deprecated"),
         patch("pytest_ansible.plugin.pytest") as mock_pytest,
     ):
-        pytest_generate_tests(metafunc)
+        pytest_generate_tests(metafunc)  # type: ignore[no-untyped-call]
         mock_pytest.exit.assert_called_once()
 
 
@@ -512,7 +508,7 @@ def test_pytest_generate_tests_ansible_host_error() -> None:
         patch.object(PyTestAnsiblePlugin, "assert_required_ansible_parameters"),
         pytest.raises(pytest.UsageError),
     ):
-        pytest_generate_tests(metafunc)
+        pytest_generate_tests(metafunc)  # type: ignore[no-untyped-call]
 
 
 def test_pytest_generate_tests_ansible_group_error() -> None:
@@ -533,7 +529,7 @@ def test_pytest_generate_tests_ansible_group_error() -> None:
         patch.object(PyTestAnsiblePlugin, "assert_required_ansible_parameters"),
         pytest.raises(pytest.UsageError),
     ):
-        pytest_generate_tests(metafunc)
+        pytest_generate_tests(metafunc)  # type: ignore[no-untyped-call]
 
 
 def test_pytest_generate_tests_molecule_scenario_parametrizes() -> None:
@@ -548,7 +544,7 @@ def test_pytest_generate_tests_molecule_scenario_parametrizes() -> None:
         patch("pytest_ansible.plugin.warn_molecule_deprecated"),
         patch("pytest_ansible.plugin.scenarios", [scenario]),
     ):
-        pytest_generate_tests(metafunc)
+        pytest_generate_tests(metafunc)  # type: ignore[no-untyped-call]
 
     metafunc.parametrize.assert_called_once_with(
         "molecule_scenario",
@@ -561,10 +557,10 @@ def test_plugin_initialize_config_only() -> None:
     """Initialize with only config (no request) covers the request skip branch."""
     config = MagicMock()
     plugin = PyTestAnsiblePlugin(config)
-    plugin._load_ansible_config = MagicMock(return_value={"inventory": "inv"})
+    plugin._load_ansible_config = MagicMock(return_value={"inventory": "inv"})  # type: ignore[method-assign]
 
     with patch("pytest_ansible.plugin.get_host_manager", return_value="hm") as mock_hm:
-        result = plugin.initialize(config=config)
+        result = plugin.initialize(config=config)  # type: ignore[no-untyped-call]
 
     assert result == "hm"
     mock_hm.assert_called_once_with(inventory="inv")
@@ -574,10 +570,10 @@ def test_plugin_initialize_request_only() -> None:
     """Initialize with only request (no config) covers the config skip branch."""
     request = MagicMock()
     plugin = PyTestAnsiblePlugin(MagicMock())
-    plugin._load_request_config = MagicMock(return_value={"user": "u"})
+    plugin._load_request_config = MagicMock(return_value={"user": "u"})  # type: ignore[method-assign]
 
     with patch("pytest_ansible.plugin.get_host_manager", return_value="hm") as mock_hm:
-        result = plugin.initialize(request=request)
+        result = plugin.initialize(request=request)  # type: ignore[no-untyped-call]
 
     assert result == "hm"
     mock_hm.assert_called_once_with(user="u")
@@ -606,7 +602,7 @@ def test_pytest_generate_tests_ansible_group_mocked() -> None:
         patch("pytest_ansible.plugin.warn_or_fail"),
         patch.object(PyTestAnsiblePlugin, "assert_required_ansible_parameters"),
     ):
-        pytest_generate_tests(metafunc)
+        pytest_generate_tests(metafunc)  # type: ignore[no-untyped-call]
 
     expected_calls = 2
     assert metafunc.parametrize.call_count == expected_calls
@@ -633,7 +629,7 @@ def test_pytest_generate_tests_ansible_host_success() -> None:
         patch("pytest_ansible.plugin.warn_or_fail"),
         patch.object(PyTestAnsiblePlugin, "assert_required_ansible_parameters"),
     ):
-        pytest_generate_tests(metafunc)
+        pytest_generate_tests(metafunc)  # type: ignore[no-untyped-call]
 
     metafunc.parametrize.assert_called_once()
 
@@ -645,9 +641,9 @@ def test_plugin_initialize_merges_config_and_request() -> None:
     plugin = PyTestAnsiblePlugin(config)
 
     with patch("pytest_ansible.plugin.get_host_manager", return_value="hm") as mock_hm:
-        plugin._load_ansible_config = MagicMock(return_value={"inventory": "inv"})
-        plugin._load_request_config = MagicMock(return_value={"user": "u"})
-        result = plugin.initialize(config=config, request=request, connection="local")
+        plugin._load_ansible_config = MagicMock(return_value={"inventory": "inv"})  # type: ignore[method-assign]
+        plugin._load_request_config = MagicMock(return_value={"user": "u"})  # type: ignore[method-assign]
+        result = plugin.initialize(config=config, request=request, connection="local")  # type: ignore[no-untyped-call]
 
     assert result == "hm"
     mock_hm.assert_called_once()
@@ -662,13 +658,17 @@ def test_assert_required_ansible_parameters_missing_inventory() -> None:
     config = MagicMock()
     config.getoption.return_value = None
     with pytest.raises(pytest.UsageError, match="Unable to find an inventory file"):
-        PyTestAnsiblePlugin.assert_required_ansible_parameters(config)
+        PyTestAnsiblePlugin.assert_required_ansible_parameters(config)  # type: ignore[no-untyped-call]
 
 
 def test_load_scenarios_git_rev_parse_failure(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """_load_scenarios warns when the directory is not a git repository."""
+    """_load_scenarios warns when the directory is not a git repository.
+
+    Args:
+        caplog: pytest log capture fixture
+    """
     from pytest_ansible.plugin import _load_scenarios
 
     config = MagicMock()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -126,7 +126,7 @@ def test_pytest_generate_tests_with_ansible_group():  # type: ignore[no-untyped-
 
     pytest_generate_tests(metafunc)  # type: ignore[no-untyped-call]
 
-    assert metafunc.parametrize.call_count == 2  # noqa: PLR2004  # Called twice for ansible_group
+    metafunc.parametrize.assert_called_once()
 
 
 def test_pytest_collection_modifyitems_with_marker():  # type: ignore[no-untyped-def]  # noqa: ANN201, D103
@@ -425,7 +425,7 @@ def test_pytest_configure_verbose_and_inject(
         mock_ansible.utils.VERBOSITY = 0
         pytest_configure(config)
         expected_verbosity = 2
-        assert expected_verbosity == mock_ansible.utils.VERBOSITY
+        assert mock_ansible.utils.VERBOSITY == expected_verbosity
 
 
 def test_pytest_configure_verbose_display_fallback() -> None:
@@ -604,8 +604,10 @@ def test_pytest_generate_tests_ansible_group_mocked() -> None:
     ):
         pytest_generate_tests(metafunc)  # type: ignore[no-untyped-call]
 
-    expected_calls = 2
-    assert metafunc.parametrize.call_count == expected_calls
+    metafunc.parametrize.assert_called_once()
+    args, _kwargs = metafunc.parametrize.call_args
+    assert args[0] == "ansible_group"
+    assert list(args[1]) == ["group1", "extra_group"]
 
 
 def test_pytest_generate_tests_ansible_host_success() -> None:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -425,7 +425,8 @@ def test_pytest_configure_verbose_and_inject(
         mock_ansible.utils.VERBOSITY = 0
         pytest_configure(config)
         expected_verbosity = 2
-        assert mock_ansible.utils.VERBOSITY == expected_verbosity
+        verbosity = mock_ansible.utils.VERBOSITY
+        assert verbosity == expected_verbosity
 
 
 def test_pytest_configure_verbose_display_fallback() -> None:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2,17 +2,28 @@
 
 from __future__ import annotations
 
+import logging
+
 from typing import TYPE_CHECKING
 from unittest import mock
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
-from pytest_ansible.plugin import PyTestAnsiblePlugin, pytest_generate_tests
+import ansible.errors
+import pytest
+
+from pytest_ansible.plugin import (
+    PyTestAnsiblePlugin,
+    pytest_addoption,
+    pytest_collect_file,
+    pytest_configure,
+    pytest_generate_tests,
+)
 
 from .conftest import skip_ansible_219
 
 
 if TYPE_CHECKING:
-    import pytest
+    from pathlib import Path
 
 
 class MockItem:
@@ -382,3 +393,293 @@ def test_pytest_load_initial_conftests_no_connection():  # type: ignore[no-untyp
         pytest_load_initial_conftests(args=["--verbose", "--ansible-connection=local"])
 
     assert len(caught) == 0
+
+
+def test_pytest_addoption_without_ansible() -> None:
+    """pytest_addoption returns early when ansible is not installed."""
+    with patch("pytest_ansible.plugin.HAS_ANSIBLE", new=False):
+        pytest_addoption(MagicMock())
+
+
+def test_pytest_configure_without_ansible() -> None:
+    """pytest_configure returns early when ansible is not installed."""
+    with patch("pytest_ansible.plugin.HAS_ANSIBLE", new=False):
+        pytest_configure(MagicMock())
+
+
+def test_pytest_configure_verbose_and_inject(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """pytest_configure sets verbosity and injects collection path."""
+    (tmp_path / "galaxy.yml").write_text(
+        "namespace: ns\nname: col\n",
+        encoding="utf-8",
+    )
+    config = MagicMock()
+    config.option.verbose = 2
+    config.option.ansible_unit_inject_only = False
+    config.invocation_params.dir = tmp_path
+    config.pluginmanager.register = MagicMock(return_value=True)
+    config.addinivalue_line = MagicMock()
+    config.rootpath = tmp_path
+
+    monkeypatch.setattr("pytest_ansible.plugin.inject", MagicMock())
+    monkeypatch.setattr("pytest_ansible.plugin._load_scenarios", MagicMock())
+
+    with (
+        patch("pytest_ansible.plugin.HAS_ANSIBLE", new=True),
+        patch("pytest_ansible.plugin.ansible") as mock_ansible,
+    ):
+        mock_ansible.utils.VERBOSITY = 0
+        pytest_configure(config)
+        expected_verbosity = 2
+        assert expected_verbosity == mock_ansible.utils.VERBOSITY
+
+
+def test_pytest_configure_verbose_display_fallback() -> None:
+    """pytest_configure uses ansible.utils.display.verbosity when VERBOSITY missing."""
+    config = MagicMock()
+    config.option.verbose = 1
+    config.option.ansible_unit_inject_only = True
+    config.pluginmanager.register = MagicMock(return_value=True)
+    config.addinivalue_line = MagicMock()
+    config.rootpath = MagicMock()
+
+    class Utils:
+        display = MagicMock()
+
+    with (
+        patch("pytest_ansible.plugin.HAS_ANSIBLE", new=True),
+        patch("pytest_ansible.plugin.ansible") as mock_ansible,
+        patch("pytest_ansible.plugin.inject_only") as mock_inject_only,
+        patch("pytest_ansible.plugin._load_scenarios"),
+    ):
+        mock_ansible.utils = Utils()
+        pytest_configure(config)
+        assert mock_ansible.utils.display.verbosity == 1
+        mock_inject_only.assert_called_once()
+
+
+def test_pytest_collect_file_molecule_yml(tmp_path: Path) -> None:
+    """pytest_collect_file returns MoleculeFile for molecule.yml."""
+    mol = tmp_path / "molecule.yml"
+    mol.write_text("---\n", encoding="utf-8")
+    parent = MagicMock()
+    parent.config.option.molecule = True
+
+    with (
+        patch("pytest_ansible.plugin.HAS_MOLECULE", new=True),
+        patch("pytest_ansible.plugin.warn_molecule_deprecated"),
+        patch("pytest_ansible.plugin.MoleculeFile") as mock_file,
+    ):
+        mock_file.from_parent.return_value = "molecule-file"
+        result = pytest_collect_file(file_path=mol, parent=parent)
+
+    assert result == "molecule-file"
+    mock_file.from_parent.assert_called_once()
+
+
+def test_pytest_generate_tests_molecule_scenario_without_molecule() -> None:
+    """pytest_generate_tests exits when molecule is missing for molecule_scenario."""
+    metafunc = MagicMock()
+    metafunc.fixturenames = ["molecule_scenario"]
+
+    with (
+        patch("pytest_ansible.plugin.HAS_MOLECULE", new=False),
+        patch("pytest_ansible.plugin.warn_molecule_deprecated"),
+        patch("pytest_ansible.plugin.pytest") as mock_pytest,
+    ):
+        pytest_generate_tests(metafunc)
+        mock_pytest.exit.assert_called_once()
+
+
+def test_pytest_generate_tests_ansible_host_error() -> None:
+    """pytest_generate_tests wraps AnsibleError as UsageError for ansible_host."""
+    metafunc = MagicMock()
+    metafunc.fixturenames = ["ansible_host"]
+    metafunc.config.getoption.side_effect = {
+        "ansible_host_pattern": "localhost",
+        "ansible_inventory": "/etc/ansible/hosts",
+    }.get
+
+    plugin = MagicMock()
+    plugin.initialize.side_effect = ansible.errors.AnsibleError("fail")
+    metafunc.config.pluginmanager.getplugin.return_value = plugin
+
+    with (
+        patch("pytest_ansible.plugin.warn_or_fail"),
+        patch.object(PyTestAnsiblePlugin, "assert_required_ansible_parameters"),
+        pytest.raises(pytest.UsageError),
+    ):
+        pytest_generate_tests(metafunc)
+
+
+def test_pytest_generate_tests_ansible_group_error() -> None:
+    """pytest_generate_tests wraps AnsibleError as UsageError for ansible_group."""
+    metafunc = MagicMock()
+    metafunc.fixturenames = ["ansible_group"]
+    metafunc.config.getoption.side_effect = {
+        "ansible_host_pattern": "localhost",
+        "ansible_inventory": "/etc/ansible/hosts",
+    }.get
+
+    plugin = MagicMock()
+    plugin.initialize.side_effect = ansible.errors.AnsibleError("fail")
+    metafunc.config.pluginmanager.getplugin.return_value = plugin
+
+    with (
+        patch("pytest_ansible.plugin.warn_or_fail"),
+        patch.object(PyTestAnsiblePlugin, "assert_required_ansible_parameters"),
+        pytest.raises(pytest.UsageError),
+    ):
+        pytest_generate_tests(metafunc)
+
+
+def test_pytest_generate_tests_molecule_scenario_parametrizes() -> None:
+    """pytest_generate_tests parametrizes molecule_scenario when molecule exists."""
+    metafunc = MagicMock()
+    metafunc.fixturenames = ["molecule_scenario"]
+    scenario = MagicMock()
+    scenario.test_id = "role-default"
+
+    with (
+        patch("pytest_ansible.plugin.HAS_MOLECULE", new=True),
+        patch("pytest_ansible.plugin.warn_molecule_deprecated"),
+        patch("pytest_ansible.plugin.scenarios", [scenario]),
+    ):
+        pytest_generate_tests(metafunc)
+
+    metafunc.parametrize.assert_called_once_with(
+        "molecule_scenario",
+        [scenario],
+        ids=["role-default"],
+    )
+
+
+def test_plugin_initialize_config_only() -> None:
+    """Initialize with only config (no request) covers the request skip branch."""
+    config = MagicMock()
+    plugin = PyTestAnsiblePlugin(config)
+    plugin._load_ansible_config = MagicMock(return_value={"inventory": "inv"})
+
+    with patch("pytest_ansible.plugin.get_host_manager", return_value="hm") as mock_hm:
+        result = plugin.initialize(config=config)
+
+    assert result == "hm"
+    mock_hm.assert_called_once_with(inventory="inv")
+
+
+def test_plugin_initialize_request_only() -> None:
+    """Initialize with only request (no config) covers the config skip branch."""
+    request = MagicMock()
+    plugin = PyTestAnsiblePlugin(MagicMock())
+    plugin._load_request_config = MagicMock(return_value={"user": "u"})
+
+    with patch("pytest_ansible.plugin.get_host_manager", return_value="hm") as mock_hm:
+        result = plugin.initialize(request=request)
+
+    assert result == "hm"
+    mock_hm.assert_called_once_with(user="u")
+
+
+def test_pytest_generate_tests_ansible_group_mocked() -> None:
+    """pytest_generate_tests parametrizes ansible_group from inventory groups."""
+    metafunc = MagicMock()
+    metafunc.fixturenames = ["ansible_group"]
+    metafunc.config.getoption.side_effect = {
+        "ansible_host_pattern": "localhost",
+        "ansible_inventory": "/etc/ansible/hosts",
+    }.get
+
+    hosts = MagicMock()
+    hosts.options = {"inventory_manager": MagicMock()}
+    hosts.options["inventory_manager"].list_groups.return_value = ["group1"]
+    hosts.get_extra_inventory_groups.return_value = ["extra_group"]
+    hosts.__getitem__ = MagicMock(side_effect=lambda key: key)
+
+    plugin = MagicMock()
+    plugin.initialize.return_value = hosts
+    metafunc.config.pluginmanager.getplugin.return_value = plugin
+
+    with (
+        patch("pytest_ansible.plugin.warn_or_fail"),
+        patch.object(PyTestAnsiblePlugin, "assert_required_ansible_parameters"),
+    ):
+        pytest_generate_tests(metafunc)
+
+    expected_calls = 2
+    assert metafunc.parametrize.call_count == expected_calls
+
+
+def test_pytest_generate_tests_ansible_host_success() -> None:
+    """pytest_generate_tests parametrizes ansible_host from inventory hosts."""
+    metafunc = MagicMock()
+    metafunc.fixturenames = ["ansible_host"]
+    metafunc.config.getoption.side_effect = {
+        "ansible_host_pattern": "localhost",
+        "ansible_inventory": "/etc/ansible/hosts",
+    }.get
+
+    hosts = MagicMock()
+    hosts.__iter__ = MagicMock(return_value=iter(["localhost"]))
+    hosts.__getitem__ = MagicMock(side_effect=lambda key: key)
+
+    plugin = MagicMock()
+    plugin.initialize.return_value = hosts
+    metafunc.config.pluginmanager.getplugin.return_value = plugin
+
+    with (
+        patch("pytest_ansible.plugin.warn_or_fail"),
+        patch.object(PyTestAnsiblePlugin, "assert_required_ansible_parameters"),
+    ):
+        pytest_generate_tests(metafunc)
+
+    metafunc.parametrize.assert_called_once()
+
+
+def test_plugin_initialize_merges_config_and_request() -> None:
+    """Initialize merges config, request, and kwargs."""
+    config = MagicMock()
+    request = MagicMock()
+    plugin = PyTestAnsiblePlugin(config)
+
+    with patch("pytest_ansible.plugin.get_host_manager", return_value="hm") as mock_hm:
+        plugin._load_ansible_config = MagicMock(return_value={"inventory": "inv"})
+        plugin._load_request_config = MagicMock(return_value={"user": "u"})
+        result = plugin.initialize(config=config, request=request, connection="local")
+
+    assert result == "hm"
+    mock_hm.assert_called_once()
+    kwargs = mock_hm.call_args.kwargs
+    assert kwargs["inventory"] == "inv"
+    assert kwargs["user"] == "u"
+    assert kwargs["connection"] == "local"
+
+
+def test_assert_required_ansible_parameters_missing_inventory() -> None:
+    """assert_required_ansible_parameters raises when inventory is falsy."""
+    config = MagicMock()
+    config.getoption.return_value = None
+    with pytest.raises(pytest.UsageError, match="Unable to find an inventory file"):
+        PyTestAnsiblePlugin.assert_required_ansible_parameters(config)
+
+
+def test_load_scenarios_git_rev_parse_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """_load_scenarios warns when the directory is not a git repository."""
+    from pytest_ansible.plugin import _load_scenarios
+
+    config = MagicMock()
+    config.rootpath.as_posix.return_value = "/tmp/not-a-repo"  # noqa: S108
+    failed = MagicMock(returncode=1, stdout="", stderr="not a git repo")
+
+    with (
+        patch("pytest_ansible.plugin.shutil.which", return_value="/usr/bin/git"),
+        patch("pytest_ansible.plugin.subprocess.run", return_value=failed),
+        caplog.at_level(logging.WARNING, logger="pytest_ansible.plugin"),
+    ):
+        _load_scenarios(config)
+
+    assert "Unable to find git root" in caplog.text

--- a/tests/unit/test_molecule_deprecation.py
+++ b/tests/unit/test_molecule_deprecation.py
@@ -88,6 +88,10 @@ def _write_molecule_yml(tmp_path: Path, data: dict) -> Path:  # type: ignore[typ
 def _make_parent(config: MagicMock, path: Path) -> MagicMock:
     """Build a parent mock suitable for MoleculeItem/File construction.
 
+    Args:
+        config: Pytest config mock
+        path: Path associated with the parent node
+
     Returns:
         A MagicMock parent with config/path/session attributes set.
     """
@@ -103,20 +107,28 @@ def _make_parent(config: MagicMock, path: Path) -> MagicMock:
 def test_molecule_pytest_configure_registers_markers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """molecule_pytest_configure should register driver/molecule markers."""
+    """molecule_pytest_configure should register driver/molecule markers.
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture
+    """
+    from types import ModuleType, SimpleNamespace
+
     config = MagicMock()
     config._metadata = {"Packages": {}}
-    config.option = MagicMock()
+    config.option = SimpleNamespace()
     added: list[str] = []
     config.addinivalue_line = lambda _section, line: added.append(line)
 
     monkeypatch.setattr(sys, "platform", "darwin")
 
-    with (
-        patch.dict("sys.modules", {"molecule": MagicMock(), "molecule.api": MagicMock()}),
-        patch("molecule.api.drivers", return_value=["default", "docker"]),
+    mock_api = ModuleType("molecule.api")
+    mock_api.drivers = lambda: ["default", "docker"]  # type: ignore[attr-defined]
+    with patch.dict(
+        "sys.modules",
+        {"molecule": ModuleType("molecule"), "molecule.api": mock_api},
     ):
-        molecule_pytest_configure(config)
+        molecule_pytest_configure(config)  # type: ignore[no-untyped-call]
 
     assert config.option.molecule["default"]["available"] is True
     assert any("no_driver:" in line for line in added)
@@ -127,10 +139,17 @@ def test_molecule_pytest_configure_selinux_import_error(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Cover the selinux ImportError branch on linux with selinux config present."""
+    """Cover the selinux ImportError branch on linux with selinux config present.
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture
+        caplog: pytest log capture fixture
+    """
+    from types import ModuleType, SimpleNamespace
+
     config = MagicMock()
     config._metadata = {"Packages": {}}
-    config.option = MagicMock()
+    config.option = SimpleNamespace()
     config.addinivalue_line = MagicMock()
 
     monkeypatch.setattr(sys, "platform", "linux")
@@ -143,35 +162,47 @@ def test_molecule_pytest_configure_selinux_import_error(
         if name == "selinux":
             msg = "no selinux"
             raise ImportError(msg)
-        return real_import(name, *args, **kwargs)
+        return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
 
+    mock_api = ModuleType("molecule.api")
+    mock_api.drivers = list  # type: ignore[attr-defined]
     with (
-        patch.dict("sys.modules", {"molecule": MagicMock(), "molecule.api": MagicMock()}),
-        patch("molecule.api.drivers", return_value=[]),
+        patch.dict(
+            "sys.modules",
+            {"molecule": ModuleType("molecule"), "molecule.api": mock_api},
+        ),
         patch.object(Path, "is_file", return_value=True),
         patch("builtins.__import__", side_effect=fake_import),
         caplog.at_level(logging.ERROR),
     ):
-        molecule_pytest_configure(config)
+        molecule_pytest_configure(config)  # type: ignore[no-untyped-call]
 
     assert "libselinux" in caplog.text
 
 
 def test_molecule_file_collect_from_parent(tmp_path: Path) -> None:
-    """MoleculeFile.collect should yield a MoleculeItem via from_parent."""
+    """MoleculeFile.collect should yield a MoleculeItem via from_parent.
+
+    Args:
+        tmp_path: Temporary directory containing molecule.yml
+    """
     path = _write_molecule_yml(tmp_path, {"driver": {"name": "default"}})
     mol_file = MagicMock(spec=MoleculeFile)
     mol_file.path = path
 
     with patch.object(MoleculeItem, "from_parent", return_value=MagicMock()) as mock_fp:
-        items = list(MoleculeFile.collect(mol_file))
+        items = list(MoleculeFile.collect(mol_file))  # type: ignore[no-untyped-call]
 
     assert len(items) == 1
     mock_fp.assert_called_once()
 
 
 def test_molecule_file_collect_legacy_constructor(tmp_path: Path) -> None:
-    """Cover the else branch when from_parent is unavailable."""
+    """Cover the else branch when from_parent is unavailable.
+
+    Args:
+        tmp_path: Temporary directory containing molecule.yml
+    """
     path = _write_molecule_yml(tmp_path, {"driver": {"name": "default"}})
     mol_file = MagicMock(spec=MoleculeFile)
     mol_file.path = path
@@ -188,14 +219,19 @@ def test_molecule_file_collect_legacy_constructor(tmp_path: Path) -> None:
         patch("builtins.hasattr", fake_hasattr),
         patch("pytest_ansible.molecule.MoleculeItem", return_value=fake_item) as mock_cls,
     ):
-        items = list(MoleculeFile.collect(mol_file))
+        items = list(MoleculeFile.collect(mol_file))  # type: ignore[no-untyped-call]
 
     assert items == [fake_item]
     mock_cls.assert_called_once()
 
 
 def test_molecule_file_str(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """MoleculeFile.__str__ returns path relative to cwd."""
+    """MoleculeFile.__str__ returns path relative to cwd.
+
+    Args:
+        tmp_path: Temporary directory containing molecule.yml
+        monkeypatch: pytest monkeypatch fixture
+    """
     rel = Path("relative/molecule.yml")
     full = tmp_path / rel
     full.parent.mkdir(parents=True)
@@ -211,7 +247,12 @@ def test_molecule_item_init_markers_and_str(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Cover MoleculeItem.__init__ marker paths, __str__, and reportinfo."""
+    """Cover MoleculeItem.__init__ marker paths, __str__, and reportinfo.
+
+    Args:
+        tmp_path: Temporary directory containing molecule.yml
+        monkeypatch: pytest monkeypatch fixture
+    """
     path = _write_molecule_yml(
         tmp_path,
         {
@@ -232,7 +273,7 @@ def test_molecule_item_init_markers_and_str(
 
     assert item.molecule_driver == "default"
     assert str(item) == "test0[default]"
-    assert item.reportinfo() == (path, 0, "use_case: test0")
+    assert item.reportinfo() == (path, 0, "use_case: test0")  # type: ignore[no-untyped-call]
     # xfail + skip + platform + molecule + driver markers
     assert mock_add_marker.call_count >= 4  # noqa: PLR2004
 
@@ -241,7 +282,12 @@ def test_molecule_item_global_config_and_unavailable_driver(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Cover global config merge and unavailable-driver marker."""
+    """Cover global config merge and unavailable-driver marker.
+
+    Args:
+        tmp_path: Temporary directory containing molecule.yml
+        monkeypatch: pytest monkeypatch fixture
+    """
     global_cfg = tmp_path / ".config" / "molecule" / "config.yml"
     global_cfg.parent.mkdir(parents=True)
     global_cfg.write_text(yaml.dump({"driver": {"name": "docker"}}), encoding="utf-8")
@@ -262,15 +308,24 @@ def test_molecule_item_global_config_and_unavailable_driver(
 
 
 def test_molecule_item_yaml_loader_empty(tmp_path: Path) -> None:
-    """yaml_loader should return {} for empty YAML documents."""
+    """yaml_loader should return {} for empty YAML documents.
+
+    Args:
+        tmp_path: Temporary directory for an empty YAML file
+    """
     empty = tmp_path / "empty.yml"
     empty.write_text("", encoding="utf-8")
     item = MoleculeItem.__new__(MoleculeItem)
-    assert item.yaml_loader(str(empty)) == {}
+    # Pass a Path: molecule.yaml_loader uses Path.open(filepath, ...) as self
+    assert item.yaml_loader(empty) == {}  # type: ignore[arg-type]
 
 
 def test_molecule_item_runtest_disabled(tmp_path: Path) -> None:
-    """Runtest should skip when --molecule is disabled."""
+    """Runtest should skip when --molecule is disabled.
+
+    Args:
+        tmp_path: Temporary directory containing molecule.yml
+    """
     path = _write_molecule_yml(tmp_path, {"driver": {"name": "default"}})
     item = MoleculeItem.__new__(MoleculeItem)
     item.path = path
@@ -280,14 +335,19 @@ def test_molecule_item_runtest_disabled(tmp_path: Path) -> None:
     item.config.getoption = MagicMock(return_value=False)
 
     with pytest.raises(pytest.skip.Exception, match="Molecule tests are disabled"):
-        MoleculeItem.runtest(item)
+        MoleculeItem.runtest(item)  # type: ignore[no-untyped-call]
 
 
 def test_molecule_item_runtest_success(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Runtest should run molecule and succeed on returncode 0."""
+    """Runtest should run molecule and succeed on returncode 0.
+
+    Args:
+        tmp_path: Temporary directory containing molecule.yml
+        monkeypatch: pytest monkeypatch fixture
+    """
     path = _write_molecule_yml(tmp_path, {"driver": {"name": "default"}})
     item = MoleculeItem.__new__(MoleculeItem)
     item.path = path
@@ -304,7 +364,7 @@ def test_molecule_item_runtest_success(
     proc.__exit__ = MagicMock(return_value=False)
 
     with patch("pytest_ansible.molecule.subprocess.Popen", return_value=proc) as mock_popen:
-        MoleculeItem.runtest(item)
+        MoleculeItem.runtest(item)  # type: ignore[no-untyped-call]
 
     cmd = mock_popen.call_args[0][0]
     assert "--base-config" in cmd
@@ -312,7 +372,11 @@ def test_molecule_item_runtest_success(
 
 
 def test_molecule_item_runtest_failure(tmp_path: Path) -> None:
-    """Runtest should fail when molecule returns non-zero."""
+    """Runtest should fail when molecule returns non-zero.
+
+    Args:
+        tmp_path: Temporary directory containing molecule.yml
+    """
     path = _write_molecule_yml(tmp_path, {"driver": {"name": "default"}})
     item = MoleculeItem.__new__(MoleculeItem)
     item.path = path
@@ -331,11 +395,15 @@ def test_molecule_item_runtest_failure(tmp_path: Path) -> None:
         patch("pytest_ansible.molecule.subprocess.Popen", return_value=proc),
         pytest.raises(pytest.fail.Exception, match="Error code 2"),
     ):
-        MoleculeItem.runtest(item)
+        MoleculeItem.runtest(item)  # type: ignore[no-untyped-call]
 
 
 def test_molecule_item_runtest_skip_no_git_change(tmp_path: Path) -> None:
-    """Runtest should skip when git diff reports no changes."""
+    """Runtest should skip when git diff reports no changes.
+
+    Args:
+        tmp_path: Temporary directory containing molecule.yml
+    """
     path = _write_molecule_yml(tmp_path, {"driver": {"name": "default"}})
     item = MoleculeItem.__new__(MoleculeItem)
     item.path = path
@@ -353,7 +421,7 @@ def test_molecule_item_runtest_skip_no_git_change(tmp_path: Path) -> None:
         patch("pytest_ansible.molecule.subprocess.Popen", return_value=git_proc),
         pytest.raises(pytest.skip.Exception, match="No change in role"),
     ):
-        MoleculeItem.runtest(item)
+        MoleculeItem.runtest(item)  # type: ignore[no-untyped-call]
 
 
 def test_molecule_exception_error() -> None:
@@ -368,7 +436,11 @@ def test_molecule_exception_error() -> None:
 
 
 def test_molecule_item_runtest_with_git_changes(tmp_path: Path) -> None:
-    """Runtest continues when git diff reports changes."""
+    """Runtest continues when git diff reports changes.
+
+    Args:
+        tmp_path: Temporary directory containing molecule.yml
+    """
     path = _write_molecule_yml(tmp_path, {"driver": {"name": "default"}})
     item = MoleculeItem.__new__(MoleculeItem)
     item.path = path
@@ -392,14 +464,19 @@ def test_molecule_item_runtest_with_git_changes(tmp_path: Path) -> None:
         "pytest_ansible.molecule.subprocess.Popen",
         side_effect=[git_proc, mol_proc],
     ):
-        MoleculeItem.runtest(item)
+        MoleculeItem.runtest(item)  # type: ignore[no-untyped-call]
 
 
 def test_molecule_scenario_test(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """MoleculeScenario.test runs molecule with optional MOLECULE_OPTS."""
+    """MoleculeScenario.test runs molecule with optional MOLECULE_OPTS.
+
+    Args:
+        tmp_path: Temporary scenario directory
+        monkeypatch: pytest monkeypatch fixture
+    """
     scenario = MoleculeScenario(
         name="default",
         parent_directory=tmp_path,
@@ -424,7 +501,12 @@ def test_molecule_scenario_test_without_opts(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """MoleculeScenario.test without MOLECULE_OPTS covers the unset branch."""
+    """MoleculeScenario.test without MOLECULE_OPTS covers the unset branch.
+
+    Args:
+        tmp_path: Temporary scenario directory
+        monkeypatch: pytest monkeypatch fixture
+    """
     scenario = MoleculeScenario(
         name="default",
         parent_directory=tmp_path,

--- a/tests/unit/test_molecule_deprecation.py
+++ b/tests/unit/test_molecule_deprecation.py
@@ -1,13 +1,28 @@
-"""Tests for molecule-via-pytest deprecation warnings."""
+"""Unit tests for molecule-via-pytest deprecation and molecule.py coverage."""
 
 from __future__ import annotations
 
+import io
+import logging
+import sys
 import warnings
 
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
 import pytest
+import yaml
 
 from pytest_ansible import molecule as molecule_mod
-from pytest_ansible.molecule import MOLECULE_DEPRECATION, warn_molecule_deprecated
+from pytest_ansible.molecule import (
+    MOLECULE_DEPRECATION,
+    MoleculeExceptionError,
+    MoleculeFile,
+    MoleculeItem,
+    MoleculeScenario,
+    molecule_pytest_configure,
+    warn_molecule_deprecated,
+)
 from pytest_ansible.plugin import pytest_load_initial_conftests
 
 
@@ -51,3 +66,377 @@ def test_molecule_cli_options_warn(args: list[str]) -> None:
     molecule_warnings = [w for w in caught if MOLECULE_DEPRECATION in str(w.message)]
     assert len(molecule_warnings) == 1
     assert issubclass(molecule_warnings[0].category, DeprecationWarning)
+
+
+def _write_molecule_yml(tmp_path: Path, data: dict) -> Path:  # type: ignore[type-arg]
+    """Write a molecule.yml under tmp_path/molecule/default.
+
+    Args:
+        tmp_path: Temporary directory root
+        data: YAML content for molecule.yml
+
+    Returns:
+        Path to molecule.yml
+    """
+    scenario = tmp_path / "molecule" / "default"
+    scenario.mkdir(parents=True, exist_ok=True)
+    path = scenario / "molecule.yml"
+    path.write_text(yaml.dump(data), encoding="utf-8")
+    return path
+
+
+def _make_parent(config: MagicMock, path: Path) -> MagicMock:
+    """Build a parent mock suitable for MoleculeItem/File construction.
+
+    Returns:
+        A MagicMock parent with config/path/session attributes set.
+    """
+    parent = MagicMock()
+    parent.config = config
+    parent.path = path
+    parent.nodeid = "node"
+    parent.session = MagicMock()
+    parent.session.config = config
+    return parent
+
+
+def test_molecule_pytest_configure_registers_markers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """molecule_pytest_configure should register driver/molecule markers."""
+    config = MagicMock()
+    config._metadata = {"Packages": {}}
+    config.option = MagicMock()
+    added: list[str] = []
+    config.addinivalue_line = lambda _section, line: added.append(line)
+
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    with (
+        patch.dict("sys.modules", {"molecule": MagicMock(), "molecule.api": MagicMock()}),
+        patch("molecule.api.drivers", return_value=["default", "docker"]),
+    ):
+        molecule_pytest_configure(config)
+
+    assert config.option.molecule["default"]["available"] is True
+    assert any("no_driver:" in line for line in added)
+    assert any(line.startswith("molecule:") for line in added)
+
+
+def test_molecule_pytest_configure_selinux_import_error(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Cover the selinux ImportError branch on linux with selinux config present."""
+    config = MagicMock()
+    config._metadata = {"Packages": {}}
+    config.option = MagicMock()
+    config.addinivalue_line = MagicMock()
+
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "selinux":
+            msg = "no selinux"
+            raise ImportError(msg)
+        return real_import(name, *args, **kwargs)
+
+    with (
+        patch.dict("sys.modules", {"molecule": MagicMock(), "molecule.api": MagicMock()}),
+        patch("molecule.api.drivers", return_value=[]),
+        patch.object(Path, "is_file", return_value=True),
+        patch("builtins.__import__", side_effect=fake_import),
+        caplog.at_level(logging.ERROR),
+    ):
+        molecule_pytest_configure(config)
+
+    assert "libselinux" in caplog.text
+
+
+def test_molecule_file_collect_from_parent(tmp_path: Path) -> None:
+    """MoleculeFile.collect should yield a MoleculeItem via from_parent."""
+    path = _write_molecule_yml(tmp_path, {"driver": {"name": "default"}})
+    mol_file = MagicMock(spec=MoleculeFile)
+    mol_file.path = path
+
+    with patch.object(MoleculeItem, "from_parent", return_value=MagicMock()) as mock_fp:
+        items = list(MoleculeFile.collect(mol_file))
+
+    assert len(items) == 1
+    mock_fp.assert_called_once()
+
+
+def test_molecule_file_collect_legacy_constructor(tmp_path: Path) -> None:
+    """Cover the else branch when from_parent is unavailable."""
+    path = _write_molecule_yml(tmp_path, {"driver": {"name": "default"}})
+    mol_file = MagicMock(spec=MoleculeFile)
+    mol_file.path = path
+    fake_item = MagicMock()
+
+    real_hasattr = hasattr
+
+    def fake_hasattr(obj: object, name: str) -> bool:
+        if name == "from_parent":
+            return False
+        return real_hasattr(obj, name)
+
+    with (
+        patch("builtins.hasattr", fake_hasattr),
+        patch("pytest_ansible.molecule.MoleculeItem", return_value=fake_item) as mock_cls,
+    ):
+        items = list(MoleculeFile.collect(mol_file))
+
+    assert items == [fake_item]
+    mock_cls.assert_called_once()
+
+
+def test_molecule_file_str(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """MoleculeFile.__str__ returns path relative to cwd."""
+    rel = Path("relative/molecule.yml")
+    full = tmp_path / rel
+    full.parent.mkdir(parents=True)
+    full.write_text("---\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    mol_file = object.__new__(MoleculeFile)
+    mol_file.path = full
+    assert str(mol_file) == str(rel)
+
+
+def test_molecule_item_init_markers_and_str(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cover MoleculeItem.__init__ marker paths, __str__, and reportinfo."""
+    path = _write_molecule_yml(
+        tmp_path,
+        {
+            "driver": {"name": "default"},
+            "platforms": [{"name": "instance"}],
+            "markers": ["xfail", "skip"],
+        },
+    )
+    config = MagicMock()
+    config.option.molecule = {"default": {"available": True}}
+    config.option.molecule_unavailable_driver = None
+    config.addinivalue_line = MagicMock()
+    parent = _make_parent(config, path)
+    monkeypatch.chdir(tmp_path)
+
+    with patch.object(MoleculeItem, "add_marker", MagicMock()) as mock_add_marker:
+        item = MoleculeItem._create("test0", parent)
+
+    assert item.molecule_driver == "default"
+    assert str(item) == "test0[default]"
+    assert item.reportinfo() == (path, 0, "use_case: test0")
+    # xfail + skip + platform + molecule + driver markers
+    assert mock_add_marker.call_count >= 4  # noqa: PLR2004
+
+
+def test_molecule_item_global_config_and_unavailable_driver(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cover global config merge and unavailable-driver marker."""
+    global_cfg = tmp_path / ".config" / "molecule" / "config.yml"
+    global_cfg.parent.mkdir(parents=True)
+    global_cfg.write_text(yaml.dump({"driver": {"name": "docker"}}), encoding="utf-8")
+
+    path = _write_molecule_yml(tmp_path, {"platforms": [{"name": "p1"}]})
+    config = MagicMock()
+    config.option.molecule = {"docker": {"available": False}}
+    config.option.molecule_unavailable_driver = "skip"
+    config.addinivalue_line = MagicMock()
+    parent = _make_parent(config, path)
+    monkeypatch.chdir(tmp_path)
+
+    with patch.object(MoleculeItem, "add_marker", MagicMock()) as mock_add_marker:
+        item = MoleculeItem._create("test1", parent)
+
+    assert item.molecule_driver == "docker"
+    mock_add_marker.assert_any_call("skip")
+
+
+def test_molecule_item_yaml_loader_empty(tmp_path: Path) -> None:
+    """yaml_loader should return {} for empty YAML documents."""
+    empty = tmp_path / "empty.yml"
+    empty.write_text("", encoding="utf-8")
+    item = MoleculeItem.__new__(MoleculeItem)
+    assert item.yaml_loader(str(empty)) == {}
+
+
+def test_molecule_item_runtest_disabled(tmp_path: Path) -> None:
+    """Runtest should skip when --molecule is disabled."""
+    path = _write_molecule_yml(tmp_path, {"driver": {"name": "default"}})
+    item = MoleculeItem.__new__(MoleculeItem)
+    item.path = path
+    item.config = MagicMock()
+    item.config.option.molecule_base_config = None
+    item.config.option.skip_no_git_change = None
+    item.config.getoption = MagicMock(return_value=False)
+
+    with pytest.raises(pytest.skip.Exception, match="Molecule tests are disabled"):
+        MoleculeItem.runtest(item)
+
+
+def test_molecule_item_runtest_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runtest should run molecule and succeed on returncode 0."""
+    path = _write_molecule_yml(tmp_path, {"driver": {"name": "default"}})
+    item = MoleculeItem.__new__(MoleculeItem)
+    item.path = path
+    item.config = MagicMock()
+    item.config.option.molecule_base_config = "/tmp/base.yml"  # noqa: S108
+    item.config.option.skip_no_git_change = None
+    item.config.getoption = MagicMock(return_value=True)
+    monkeypatch.setenv("MOLECULE_OPTS", "--debug")
+
+    proc = MagicMock()
+    proc.stdout = io.StringIO("ok\n")
+    proc.returncode = 0
+    proc.__enter__ = MagicMock(return_value=proc)
+    proc.__exit__ = MagicMock(return_value=False)
+
+    with patch("pytest_ansible.molecule.subprocess.Popen", return_value=proc) as mock_popen:
+        MoleculeItem.runtest(item)
+
+    cmd = mock_popen.call_args[0][0]
+    assert "--base-config" in cmd
+    assert "--debug" in cmd
+
+
+def test_molecule_item_runtest_failure(tmp_path: Path) -> None:
+    """Runtest should fail when molecule returns non-zero."""
+    path = _write_molecule_yml(tmp_path, {"driver": {"name": "default"}})
+    item = MoleculeItem.__new__(MoleculeItem)
+    item.path = path
+    item.config = MagicMock()
+    item.config.option.molecule_base_config = None
+    item.config.option.skip_no_git_change = None
+    item.config.getoption = MagicMock(return_value=True)
+
+    proc = MagicMock()
+    proc.stdout = io.StringIO("boom\n")
+    proc.returncode = 2
+    proc.__enter__ = MagicMock(return_value=proc)
+    proc.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("pytest_ansible.molecule.subprocess.Popen", return_value=proc),
+        pytest.raises(pytest.fail.Exception, match="Error code 2"),
+    ):
+        MoleculeItem.runtest(item)
+
+
+def test_molecule_item_runtest_skip_no_git_change(tmp_path: Path) -> None:
+    """Runtest should skip when git diff reports no changes."""
+    path = _write_molecule_yml(tmp_path, {"driver": {"name": "default"}})
+    item = MoleculeItem.__new__(MoleculeItem)
+    item.path = path
+    item.config = MagicMock()
+    item.config.option.molecule_base_config = None
+    item.config.option.skip_no_git_change = "HEAD~1"
+    item.config.getoption = MagicMock(return_value=True)
+
+    git_proc = MagicMock()
+    git_proc.stdout = io.StringIO("")
+    git_proc.__enter__ = MagicMock(return_value=git_proc)
+    git_proc.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("pytest_ansible.molecule.subprocess.Popen", return_value=git_proc),
+        pytest.raises(pytest.skip.Exception, match="No change in role"),
+    ):
+        MoleculeItem.runtest(item)
+
+
+def test_molecule_exception_error() -> None:
+    """MoleculeExceptionError should be a regular Exception subclass.
+
+    Raises:
+        MoleculeExceptionError: Always, to assert the exception type.
+    """
+    msg = "boom"
+    with pytest.raises(MoleculeExceptionError):
+        raise MoleculeExceptionError(msg)
+
+
+def test_molecule_item_runtest_with_git_changes(tmp_path: Path) -> None:
+    """Runtest continues when git diff reports changes."""
+    path = _write_molecule_yml(tmp_path, {"driver": {"name": "default"}})
+    item = MoleculeItem.__new__(MoleculeItem)
+    item.path = path
+    item.config = MagicMock()
+    item.config.option.molecule_base_config = None
+    item.config.option.skip_no_git_change = "HEAD~1"
+    item.config.getoption = MagicMock(return_value=True)
+
+    git_proc = MagicMock()
+    git_proc.stdout = io.StringIO("M roles/foo/tasks/main.yml\n")
+    git_proc.__enter__ = MagicMock(return_value=git_proc)
+    git_proc.__exit__ = MagicMock(return_value=False)
+
+    mol_proc = MagicMock()
+    mol_proc.stdout = io.StringIO("ok\n")
+    mol_proc.returncode = 0
+    mol_proc.__enter__ = MagicMock(return_value=mol_proc)
+    mol_proc.__exit__ = MagicMock(return_value=False)
+
+    with patch(
+        "pytest_ansible.molecule.subprocess.Popen",
+        side_effect=[git_proc, mol_proc],
+    ):
+        MoleculeItem.runtest(item)
+
+
+def test_molecule_scenario_test(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MoleculeScenario.test runs molecule with optional MOLECULE_OPTS."""
+    scenario = MoleculeScenario(
+        name="default",
+        parent_directory=tmp_path,
+        test_id="role-default",
+    )
+    monkeypatch.setenv("MOLECULE_OPTS", "--destroy=always")
+    completed = MagicMock()
+
+    with (
+        patch("pytest_ansible.molecule.warn_molecule_deprecated"),
+        patch("pytest_ansible.molecule.subprocess.run", return_value=completed) as mock_run,
+    ):
+        result = scenario.test()
+
+    assert result is completed
+    args = mock_run.call_args.kwargs["args"]
+    assert "default" in args
+    assert "--destroy=always" in args
+
+
+def test_molecule_scenario_test_without_opts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MoleculeScenario.test without MOLECULE_OPTS covers the unset branch."""
+    scenario = MoleculeScenario(
+        name="default",
+        parent_directory=tmp_path,
+        test_id="role-default",
+    )
+    monkeypatch.delenv("MOLECULE_OPTS", raising=False)
+
+    with (
+        patch("pytest_ansible.molecule.warn_molecule_deprecated"),
+        patch("pytest_ansible.molecule.subprocess.run", return_value=MagicMock()) as mock_run,
+    ):
+        scenario.test()
+
+    args = mock_run.call_args.kwargs["args"]
+    assert args == [sys.executable, "-m", "molecule", "test", "-s", "default"]

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -618,10 +618,11 @@ def test_has_version_import_error_branch() -> None:
             msg = name
             raise AttributeError(msg)
 
-    with patch.dict(sys.modules, {"ansible": BrokenAnsible()}):
+    try:
+        with patch.dict(sys.modules, {"ansible": BrokenAnsible()}):
+            importlib.reload(hv)
+            assert hv.has_ansible_v2 is False
+            assert hv.has_ansible_v219 is False
+    finally:
         importlib.reload(hv)
-        assert hv.has_ansible_v2 is False
-        assert hv.has_ansible_v219 is False
-
-    importlib.reload(hv)
     assert hv.has_ansible_v213 is True

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import logging
 import re
 import subprocess  # noqa: S404
@@ -10,13 +11,21 @@ import sys
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
+from pytest_ansible import units as units_mod
 from pytest_ansible.module_dispatcher.v213 import (
     ModuleDispatcherV213,
     ResultAccumulator,
     _execute_play,
 )
 from pytest_ansible.molecule import _populate_config_metadata
-from pytest_ansible.units import _resolve_collections_dir, inject, inject_only
+from pytest_ansible.units import (
+    _resolve_collections_dir,
+    acf_inject,
+    determine_envvar,
+    get_collection_name,
+    inject,
+    inject_only,
+)
 
 
 if TYPE_CHECKING:
@@ -203,8 +212,7 @@ def test_resolve_collections_dir_creates_symlinks(tmp_path: Path) -> None:
 def test_for_params():  # type: ignore[no-untyped-def]  # noqa: ANN201
     """Test for params."""
     proc = subprocess.run(
-        "pytest --help",  # noqa: S607
-        shell=True,
+        [sys.executable, "-m", "pytest", "--help"],
         capture_output=True,
         check=False,
     )
@@ -383,3 +391,199 @@ def test_build_tqm_kwargs_extra() -> None:
     assert result["inventory"] is extra_inv
     assert result["variable_manager"] is extra_vm
     assert result["loader"] is extra_loader
+
+
+def test_get_collection_name_success(tmp_path: Path) -> None:
+    """get_collection_name returns namespace/name from galaxy.yml."""
+    (tmp_path / "galaxy.yml").write_text(
+        "namespace: my_ns\nname: my_col\n",
+        encoding="utf-8",
+    )
+    namespace, name = get_collection_name(tmp_path)
+    assert namespace == "my_ns"
+    assert name == "my_col"
+
+
+def test_get_collection_name_missing_file(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """get_collection_name returns None when galaxy.yml is absent."""
+    with caplog.at_level(logging.ERROR):
+        namespace, name = get_collection_name(tmp_path)
+    assert namespace is None
+    assert name is None
+    assert "No galaxy.yml" in caplog.text
+
+
+def test_get_collection_name_missing_keys(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """get_collection_name returns None when galaxy.yml lacks namespace/name."""
+    (tmp_path / "galaxy.yml").write_text("version: 1.0.0\n", encoding="utf-8")
+    with caplog.at_level(logging.ERROR):
+        namespace, name = get_collection_name(tmp_path)
+    assert namespace is None
+    assert name is None
+    assert "does not contain namespace" in caplog.text
+
+
+def test_inject_without_ansible(caplog: pytest.LogCaptureFixture) -> None:
+    """Inject returns early when ansible is unavailable."""
+    with (
+        patch.object(units_mod, "HAS_ANSIBLE", new=False),
+        caplog.at_level(logging.ERROR),
+    ):
+        inject(MagicMock())
+    assert "ansible is not installed" in caplog.text
+
+
+def test_inject_without_yaml(caplog: pytest.LogCaptureFixture) -> None:
+    """Inject returns early when pyyaml is unavailable."""
+    with (
+        patch.object(units_mod, "HAS_ANSIBLE", new=True),
+        patch.object(units_mod, "HAS_YAML", new=False),
+        caplog.at_level(logging.ERROR),
+    ):
+        inject(MagicMock())
+    assert "pyyaml is not installed" in caplog.text
+
+
+def test_inject_without_collection_name(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inject returns early when collection name cannot be resolved."""
+    monkeypatch.setattr(
+        units_mod,
+        "get_collection_name",
+        lambda _path: (None, None),
+    )
+    with (
+        patch.object(units_mod, "HAS_ANSIBLE", new=True),
+        patch.object(units_mod, "HAS_YAML", new=True),
+    ):
+        inject(tmp_path)
+
+
+def test_inject_with_collections_path_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inject honors COLLECTIONS_PATH and COLLECTIONS_PATHS env vars."""
+    monkeypatch.setattr(
+        units_mod,
+        "get_collection_name",
+        lambda _path: ("ns", "col"),
+    )
+    monkeypatch.setenv("COLLECTIONS_PATH", str(tmp_path / "extra1"))
+    monkeypatch.setenv("COLLECTIONS_PATHS", str(tmp_path / "extra2"))
+    (tmp_path / "collections" / "ansible_collections").mkdir(parents=True)
+
+    with (
+        patch.object(units_mod, "HAS_ANSIBLE", new=True),
+        patch.object(units_mod, "HAS_YAML", new=True),
+        patch.object(units_mod, "acf_inject") as mock_acf,
+    ):
+        inject(tmp_path)
+
+    mock_acf.assert_called_once()
+    paths = mock_acf.call_args.kwargs["paths"]
+    assert any("extra1" in p for p in paths)
+    assert any("extra2" in p for p in paths)
+
+
+def test_acf_inject_without_collection_finder(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """acf_inject logs when collection finder is unavailable."""
+    with (
+        patch.object(units_mod, "HAS_COLLECTION_FINDER", new=False),
+        caplog.at_level(logging.DEBUG),
+    ):
+        acf_inject(paths=["/tmp/collections"])  # noqa: S108
+    assert "_ACF not available" in caplog.text
+
+
+def test_determine_envvar_without_collection_finder() -> None:
+    """determine_envvar returns ANSIBLE_COLLECTIONS_PATHS without finder."""
+    with patch.object(units_mod, "HAS_COLLECTION_FINDER", new=False):
+        assert determine_envvar() == "ANSIBLE_COLLECTIONS_PATHS"
+
+
+def test_determine_envvar_with_collection_finder() -> None:
+    """determine_envvar returns ANSIBLE_COLLECTIONS_PATH with finder."""
+    with patch.object(units_mod, "HAS_COLLECTION_FINDER", new=True):
+        assert determine_envvar() == "ANSIBLE_COLLECTIONS_PATH"
+
+
+def test_inject_only_skips_empty_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    """inject_only should ignore empty PATH segments."""
+    monkeypatch.setenv("ANSIBLE_COLLECTIONS_PATH", "")
+    original_path = list(sys.path)
+    try:
+        with patch.object(units_mod, "acf_inject") as mock_acf:
+            units_mod.inject_only()
+        mock_acf.assert_called_once()
+    finally:
+        sys.path[:] = original_path
+
+
+def test_units_reload_without_yaml_and_collection_finder() -> None:
+    """Cover ImportError fallbacks when yaml / collection finder are unavailable."""
+    import importlib
+
+    saved_yaml = sys.modules.get("yaml")
+    finder_key = "ansible.utils.collection_loader._collection_finder"
+    saved_finder = sys.modules.get(finder_key)
+
+    try:
+        sys.modules["yaml"] = None  # type: ignore[assignment]
+        sys.modules[finder_key] = None  # type: ignore[assignment]
+        reloaded = importlib.reload(units_mod)
+        assert reloaded.HAS_YAML is False
+        assert reloaded.HAS_COLLECTION_FINDER is False
+    finally:
+        if saved_yaml is not None:
+            sys.modules["yaml"] = saved_yaml
+        else:
+            sys.modules.pop("yaml", None)
+        if saved_finder is not None:
+            sys.modules[finder_key] = saved_finder
+        else:
+            sys.modules.pop(finder_key, None)
+        importlib.reload(units_mod)
+        assert units_mod.HAS_YAML is True
+
+
+def test_has_version_import_error_branch() -> None:
+    """Cover the ImportError/AttributeError fallback in has_version."""
+    import pytest_ansible.has_version as hv
+
+    class BrokenAnsible:
+        """ansible stand-in whose version access raises AttributeError."""
+
+        @property
+        def version(self) -> str:
+            """Raise to simulate a broken ansible install.
+
+            Raises:
+                AttributeError: Always raised to mimic a broken install.
+            """
+            msg = "missing"
+            raise AttributeError(msg)
+
+        def __getattr__(self, name: str) -> str:
+            if name == "__version__":
+                return self.version
+            msg = name
+            raise AttributeError(msg)
+
+    with patch.dict(sys.modules, {"ansible": BrokenAnsible()}):
+        importlib.reload(hv)
+        assert hv.has_ansible_v2 is False
+        assert hv.has_ansible_v219 is False
+
+    importlib.reload(hv)
+    assert hv.has_ansible_v213 is True

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -394,7 +394,11 @@ def test_build_tqm_kwargs_extra() -> None:
 
 
 def test_get_collection_name_success(tmp_path: Path) -> None:
-    """get_collection_name returns namespace/name from galaxy.yml."""
+    """get_collection_name returns namespace/name from galaxy.yml.
+
+    Args:
+        tmp_path: Temporary directory containing galaxy.yml
+    """
     (tmp_path / "galaxy.yml").write_text(
         "namespace: my_ns\nname: my_col\n",
         encoding="utf-8",
@@ -408,7 +412,12 @@ def test_get_collection_name_missing_file(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """get_collection_name returns None when galaxy.yml is absent."""
+    """get_collection_name returns None when galaxy.yml is absent.
+
+    Args:
+        tmp_path: Temporary directory without galaxy.yml
+        caplog: pytest log capture fixture
+    """
     with caplog.at_level(logging.ERROR):
         namespace, name = get_collection_name(tmp_path)
     assert namespace is None
@@ -420,7 +429,12 @@ def test_get_collection_name_missing_keys(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """get_collection_name returns None when galaxy.yml lacks namespace/name."""
+    """get_collection_name returns None when galaxy.yml lacks namespace/name.
+
+    Args:
+        tmp_path: Temporary directory with incomplete galaxy.yml
+        caplog: pytest log capture fixture
+    """
     (tmp_path / "galaxy.yml").write_text("version: 1.0.0\n", encoding="utf-8")
     with caplog.at_level(logging.ERROR):
         namespace, name = get_collection_name(tmp_path)
@@ -430,7 +444,11 @@ def test_get_collection_name_missing_keys(
 
 
 def test_inject_without_ansible(caplog: pytest.LogCaptureFixture) -> None:
-    """Inject returns early when ansible is unavailable."""
+    """Inject returns early when ansible is unavailable.
+
+    Args:
+        caplog: pytest log capture fixture
+    """
     with (
         patch.object(units_mod, "HAS_ANSIBLE", new=False),
         caplog.at_level(logging.ERROR),
@@ -440,7 +458,11 @@ def test_inject_without_ansible(caplog: pytest.LogCaptureFixture) -> None:
 
 
 def test_inject_without_yaml(caplog: pytest.LogCaptureFixture) -> None:
-    """Inject returns early when pyyaml is unavailable."""
+    """Inject returns early when pyyaml is unavailable.
+
+    Args:
+        caplog: pytest log capture fixture
+    """
     with (
         patch.object(units_mod, "HAS_ANSIBLE", new=True),
         patch.object(units_mod, "HAS_YAML", new=False),
@@ -454,7 +476,12 @@ def test_inject_without_collection_name(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Inject returns early when collection name cannot be resolved."""
+    """Inject returns early when collection name cannot be resolved.
+
+    Args:
+        tmp_path: Temporary collection path
+        monkeypatch: pytest monkeypatch fixture
+    """
     monkeypatch.setattr(
         units_mod,
         "get_collection_name",
@@ -471,7 +498,12 @@ def test_inject_with_collections_path_env(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Inject honors COLLECTIONS_PATH and COLLECTIONS_PATHS env vars."""
+    """Inject honors COLLECTIONS_PATH and COLLECTIONS_PATHS env vars.
+
+    Args:
+        tmp_path: Temporary collection path
+        monkeypatch: pytest monkeypatch fixture
+    """
     monkeypatch.setattr(
         units_mod,
         "get_collection_name",
@@ -497,7 +529,11 @@ def test_inject_with_collections_path_env(
 def test_acf_inject_without_collection_finder(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """acf_inject logs when collection finder is unavailable."""
+    """acf_inject logs when collection finder is unavailable.
+
+    Args:
+        caplog: pytest log capture fixture
+    """
     with (
         patch.object(units_mod, "HAS_COLLECTION_FINDER", new=False),
         caplog.at_level(logging.DEBUG),
@@ -519,7 +555,11 @@ def test_determine_envvar_with_collection_finder() -> None:
 
 
 def test_inject_only_skips_empty_paths(monkeypatch: pytest.MonkeyPatch) -> None:
-    """inject_only should ignore empty PATH segments."""
+    """inject_only should ignore empty PATH segments.
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture
+    """
     monkeypatch.setenv("ANSIBLE_COLLECTIONS_PATH", "")
     original_path = list(sys.path)
     try:
@@ -532,8 +572,6 @@ def test_inject_only_skips_empty_paths(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_units_reload_without_yaml_and_collection_finder() -> None:
     """Cover ImportError fallbacks when yaml / collection finder are unavailable."""
-    import importlib
-
     saved_yaml = sys.modules.get("yaml")
     finder_key = "ansible.utils.collection_loader._collection_finder"
     saved_finder = sys.modules.get(finder_key)


### PR DESCRIPTION
## Summary
- Raise unit-test coverage to ~99% so SonarCloud Quality Gate can pass.
- Fix `ansible_group` parametrization: pytest rejects two `parametrize` calls for the same fixture; merge primary + extra inventory groups once with stable dedupe.
- Resolve Sonar smells, CodeRabbit findings, and lint/py310 CI failures from the coverage work.

## Changes
- Expand unit tests for molecule, units, plugin, host_manager, module_dispatcher, and results.
- `plugin.py`: single `metafunc.parametrize("ansible_group", …)` over `dict.fromkeys([*groups, *extra_groups])`.
- Harden reload cleanup in `has_version` tests; satisfy Sonar/ruff assert-order conflict.
- Dictionary updates for cspell (`fromlist`, `nodeid`, `delenv`).

## Test plan
- [x] `tox -e lint` passes
- [x] `tox -e py` passes
- [x] CI green on PR #609